### PR TITLE
ci: only trigger CI on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
     pull_request:
-    push:
-        branches: [main]
 
 concurrency:
     group: ci-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Removing the push-to-main trigger avoids re-running the full CI
suite after a PR is merged, since the merge already produced a
green run on the PR.

https://claude.ai/code/session_01K24cBYYxkCJB6dyNsYHTsq