### PR TITLE
ci: pre-build assets on runner with MariaDB service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,9 +28,6 @@ vendor/
 .env*
 /.phpunit.cache
 .phpunit.result.cache
-node_modules/
-bootstrap/ssr/
-public/build/
 Homestead.json
 Homestead.yaml
 npm-debug.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,14 @@ jobs:
                   cache: true
 
             - name: Prepare Laravel environment (Wayfinder needs a booted app + DB schema)
+              # .env.example points at MariaDB which is not available in CI, so
+              # override to SQLite locally for the tsc/lint/format checks.
+              # Production parity (Wayfinder types from MariaDB) is enforced in
+              # the deploy workflow.
               run: |
                   cp .env.example .env
+                  sed -i 's/^DB_CONNECTION=.*/DB_CONNECTION=sqlite/' .env
+                  sed -i 's|^DB_DATABASE=.*|DB_DATABASE=database/database.sqlite|' .env
                   php artisan key:generate --force --ansi
                   touch database/database.sqlite
                   php artisan migrate --force --ansi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,8 +17,57 @@ jobs:
     permissions:
       contents: read
       packages: write
+    services:
+      # Wayfinder (dev-next) introspects the live DB schema at generate time.
+      # Running against the same engine as production (MariaDB) is required so
+      # generated TS types match runtime PDO behaviour (e.g. INT columns are
+      # returned as `string` by MariaDB but `number` by SQLite).
+      mariadb:
+        image: mariadb:11
+        env:
+          MARIADB_ROOT_PASSWORD: secret
+          MARIADB_DATABASE: pingcrm
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mariadb-admin ping --silent"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=10
+    env:
+      DB_HOST: 127.0.0.1
+      DB_PORT: '3306'
+      DB_DATABASE: pingcrm
+      DB_USERNAME: root
+      DB_PASSWORD: secret
     steps:
       - uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          extensions: dom, curl, libxml, mbstring, zip, pdo, pdo_mysql, bcmath, intl
+          coverage: none
+          tools: composer:v2
+
+      - name: Install Composer dependencies (no-dev — matches production)
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: '--no-dev'
+
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version-file: .nvmrc
+          cache: true
+
+      - name: Load env, migrate MariaDB and pre-build assets
+        run: |
+          echo "${{ secrets.ENV_FILE_BASE64 }}" | base64 -d > .env
+          php artisan key:generate --force --ansi
+          php artisan migrate --force --no-interaction
+          vp install
+          vp run build:ssr
 
       - uses: docker/setup-buildx-action@v3
 
@@ -27,11 +76,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Load env file for build
-        run: |
-          echo "${{ secrets.ENV_FILE_BASE64 }}" | base64 -d > .env.build
-          echo "ENV_BUILD_HASH=$(sha256sum .env.build | cut -c1-8)" >> $GITHUB_ENV
 
       - name: Build and push App image
         uses: docker/build-push-action@v5
@@ -44,14 +88,10 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-app
           cache-from: type=gha,scope=app
           cache-to: type=gha,mode=max,scope=app
-          build-args: |
-            ENV_HASH=${{ env.ENV_BUILD_HASH }}
-          secret-files: |
-            dotenv=./.env.build
 
-      - name: Cleanup build env
+      - name: Cleanup pre-build env
         if: always()
-        run: rm -f .env.build
+        run: rm -f .env
 
   deploy:
     needs: build

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,11 +34,10 @@ RUN docker-php-serversideup-set-id www-data $USER_ID:$GROUP_ID  && \
 USER www-data
 
 ############################################
-# Builder Stage
+# Builder Stage (vendor only — JS assets are pre-built on the CI runner
+# against a real MariaDB so Wayfinder generates types that match production)
 ############################################
 FROM base AS builder
-
-COPY --from=oven/bun:1.3-debian /usr/local/bin/bun /usr/local/bin/bun
 
 COPY --link composer.json composer.lock ./
 
@@ -50,26 +49,9 @@ RUN composer install \
     --no-scripts \
     --audit
 
-COPY --link package.json bun.lock* ./
-
-RUN bun install --frozen-lockfile
-
 COPY --link . .
 
 RUN composer dump-autoload --classmap-authoritative --no-dev
-
-ARG ENV_HASH
-# Wayfinder (dev-next) introspects the DB schema at generate time (via laravel/ranger
-# RouteBindingResolver). Since no real DB is reachable during image build, we spin up
-# a throwaway SQLite DB, migrate it, and point the build at it. Remove once
-# https://github.com/laravel/wayfinder/issues/214 is fixed.
-RUN --mount=type=secret,id=dotenv \
-    echo "Build with ENV_HASH=${ENV_HASH}" && \
-    set -a && . /run/secrets/dotenv && set +a && \
-    export DB_CONNECTION=sqlite DB_DATABASE=/tmp/wayfinder.sqlite && \
-    : > "$DB_DATABASE" && \
-    php artisan migrate --force --no-interaction && \
-    bun run build:ssr
 
 ############################################
 # App Image (also runs SSR via `php artisan inertia:start-ssr --runtime=bun`)
@@ -81,12 +63,6 @@ COPY --from=oven/bun:1.3-debian /usr/local/bin/bun /usr/local/bin/bun
 COPY --link --chown=33:33 --from=builder /var/www/html/vendor ./vendor
 
 COPY --link --chown=33:33 . .
-
-COPY --link --chown=33:33 --from=builder /var/www/html/public/build ./public/build
-
-COPY --link --chown=33:33 --from=builder /var/www/html/bootstrap/ssr ./bootstrap/ssr
-
-COPY --link --chown=33:33 --from=builder /var/www/html/node_modules ./node_modules
 
 RUN mkdir -p \
     storage/logs \


### PR DESCRIPTION
## Summary

- Move JS/Wayfinder asset build out of the Dockerfile and onto the GitHub Actions runner, using a `mariadb:11` service container so Wayfinder generates types against the same DB engine as production.
- Simplify the `builder` stage to vendor-only; pre-built `public/build`, `bootstrap/ssr`, `node_modules` and `resources/js/wayfinder` ship via the Docker build context.
- Adjust `.dockerignore` so the context carries those pre-built directories.

## Why MariaDB, not SQLite

Wayfinder (dev-next) introspects the live DB schema at generate time. The previous Dockerfile spun up a throwaway SQLite to satisfy that, but the generated TS types diverged from production silently:

| Field | SQLite | MariaDB |
| --- | --- | --- |
| `User.account_id` | `number` | **`string`** |
| `Contact.organization_id` | `number \| null` | **`string \| null`** |

`INT` columns are returned as `string` by MariaDB through PDO and `number` by SQLite. The committed types match the MariaDB shape, so SQLite-built bundles would have mismatched runtime types.

Verified locally by building twice from the same clean source (cache wiped) against each engine and diffing `resources/js/wayfinder/types.d.ts`.

## Test plan

- [ ] Workflow runs on `workflow_dispatch` from `main`
- [ ] `build` job: MariaDB service comes up, migration succeeds, `vp run build:ssr` produces `public/build` + `bootstrap/ssr`
- [ ] Docker image is pushed to `ghcr.io` with pre-built assets baked in
- [ ] `deploy` job still picks up the image and converges on the Swarm stack
- [ ] App boots and SSR responds (no missing Wayfinder types at runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)