### PR TITLE
fix(compose): replace horizon service with queue:work

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -70,10 +70,11 @@ services:
         - "traefik.http.routers.pingcrm.rule=Host(`${APP_HOST}`)"
         - "traefik.http.services.pingcrm.loadbalancer.server.port=8000"
 
-  horizon:
+  queue:
     <<: *base
-    command: ["php", "/var/www/html/artisan", "horizon"]
+    command: ["php", "/var/www/html/artisan", "queue:work", "--tries=3", "--max-time=3600"]
     stop_signal: SIGTERM
+    stop_grace_period: 60s
     networks: *default-network
     deploy:
       update_config:
@@ -89,12 +90,6 @@ services:
         delay: 10s
         max_attempts: 3
         window: 120s
-    healthcheck:
-      test: ["CMD", "healthcheck-horizon"]
-      start_period: 10s
-      interval: 5s
-      timeout: 5s
-      retries: 2
 
   scheduler:
     <<: *base


### PR DESCRIPTION
## Context

The latest workflow_dispatch deploy (run [25922693722](https://github.com/fouteox/pingcrm-react-inertia-laravel/actions/runs/25922693722)) timed out at \`Deploy stack\` — Swarm could not converge because the \`horizon\` task was crashlooping:

\`\`\`
ERROR  Command "horizon" is not defined.
Docker CMD: php /var/www/html/artisan horizon
\`\`\`

\`laravel/horizon\` was removed from \`composer.json\` in #24 (Apr 19, "Use spin on dev"), but \`compose.prod.yaml\` was not updated and still spawned a \`horizon\` service running \`php artisan horizon\`.

Deploys between #24 and now didn't surface the bug because the image hash didn't change and Swarm didn't roll the existing crashloop. The latest deploy rolled the image and exposed the issue.

## Fix

Replace the \`horizon:\` service with a \`queue:\` service that runs \`php artisan queue:work\` against the existing redis (valkey) connection. Swarm's \`--prune\` on the next deploy will remove the stale \`..._horizon\` service automatically.

## Test plan

- [ ] \`docker stack deploy\` converges within the 5-minute timeout
- [ ] On the host: \`docker stack services <stack>\` shows \`..._queue 1/1\` and no \`..._horizon\`
- [ ] \`docker service logs <stack>_queue\` shows the worker waiting for jobs
- [ ] Trigger a queued job (e.g. a search re-index via Scout) and confirm it is consumed

🤖 Generated with [Claude Code](https://claude.com/claude-code)