### PR TITLE
fix(compose): healthcheck on queue service

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -90,6 +90,12 @@ services:
         delay: 10s
         max_attempts: 3
         window: 120s
+    healthcheck:
+      test: ["CMD", "healthcheck-queue"]
+      start_period: 10s
+      interval: 5s
+      timeout: 5s
+      retries: 2
 
   scheduler:
     <<: *base


### PR DESCRIPTION
## Diagnosis

After #29, the new \`queue\` service still failed to converge. The Swarm task history showed tasks finishing in **\`Shutdown / Complete\`** (exit 0) every ~1 minute, not crashing — so this was not a queue:work crash.

The serversideup/php base image ships a default \`HEALTHCHECK\` that pings \`http://localhost:\$CADDY_HTTP_PORT/\$HEALTHCHECK_PATH\`. The queue worker doesn't bind any HTTP port, so the default healthcheck failed → Docker marked the container unhealthy → Swarm sent SIGTERM → \`queue:work\` shut down gracefully (exit 0) → Swarm logged it as Complete and restarted → loop.

The other PHP services (app/scheduler/reverb) all override the default by pointing at a \`healthcheck-*\` helper that ships with the image. \`healthcheck-queue\` exists too — confirmed via:

\`\`\`
$ docker run --rm --entrypoint sh <image> -c 'ls /usr/local/bin/healthcheck-*'
/usr/local/bin/healthcheck-horizon
/usr/local/bin/healthcheck-octane
/usr/local/bin/healthcheck-queue
/usr/local/bin/healthcheck-reverb
/usr/local/bin/healthcheck-schedule
\`\`\`

## Fix

Mirror the scheduler/reverb pattern and wire \`healthcheck-queue\` to the queue service.

## Test plan

- [ ] \`docker stack deploy\` converges within the timeout
- [ ] \`docker stack services <stack>\` shows \`..._queue 1/1\`
- [ ] Task history stops accumulating Shutdown / Complete entries
- [ ] \`docker service logs <stack>_queue\` shows the worker waiting for jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)