### PR TITLE
ci: switch Docker layer cache from GHA to registry backend

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,8 +87,8 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-app
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:run-${{ github.run_number }}
-          cache-from: type=gha,scope=app
-          cache-to: type=gha,mode=max,scope=app
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
 
       - name: Cleanup pre-build env
         if: always()


### PR DESCRIPTION
## Summary
- The first real run of `build.yml` after #32 failed at the `exporting to GitHub Actions Cache` step with `error writing layer blob: failed to reserve cache` — the image itself (`:latest`, `:<sha>-app`, `:run-1`) had already pushed successfully to ghcr, only the GHA cache export failed.
- This is a known reliability issue with the GitHub Actions Cache service API under `mode=max` ([docker/buildx#841](https://github.com/docker/buildx/issues/841), [#1728](https://github.com/docker/buildx/issues/1728), [docker/build-push-action#1181](https://github.com/docker/build-push-action/issues/1181)).
- Docker's own docs are explicit about the fix for `max` mode: ["push the image and the cache separately using the registry cache exporter"](https://docs.docker.com/build/ci/github-actions/cache/#registry-cache) — `gha` isn't meant to carry `mode=max` reliably.
- Switched `cache-from`/`cache-to` from `type=gha` to `type=registry`, storing the cache under a dedicated `:buildcache` tag on the same ghcr repo the job already authenticates to (no new secrets/permissions). This also sidesteps GitHub's shared 10GB Actions-cache quota/eviction policy entirely, since registry storage isn't subject to it.

## Test plan
- [x] YAML validated as syntactically correct
- [ ] Next merge to main: confirm the `build` job's cache export step succeeds and a `ghcr.io/fouteox/pingcrm-react-inertia-laravel:buildcache` tag appears