### PR TITLE
ci: security updates for the build supply chain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+# Dependabot: version updates on the build supply chain (Dockerfile FROMs —
+# digest-pinned, tag + digest kept in sync — and GitHub Actions). Composer
+# version noise is deliberately excluded: its security PRs come from
+# Dependabot security updates, enabled at the repository level.
+#
+# bun: Dependabot security updates don't support it yet (alerts via bun.lock
+# yes, auto-fix no — GitHub changelog). Compensation: a monthly grouped
+# version-updates PR keeps the JS lockfile fresh.
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      actions:
+        patterns: ["*"]
+  - package-ecosystem: bun
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      js-dependencies:
+        patterns: ["*"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,12 @@ on:
     types: [closed]
     branches: [main]
   workflow_dispatch:
+  schedule:
+    # Weekly security rebuild (Mondays 05:00 UTC, staggered after fadogen and
+    # footeox): base images ship security fixes under the SAME tag — they only
+    # reach us on a fresh build. The run produces a new run-N tag, so Flux
+    # Image Automation rolls it out.
+    - cron: '0 5 * * 1'
 
 env:
   REGISTRY: ghcr.io
@@ -12,7 +18,7 @@ env:
 
 jobs:
   build:
-    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     runs-on: ${{ vars.SYSTEM_ARCH == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     permissions:
       contents: read
@@ -88,6 +94,12 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-app
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:run-${{ github.run_number }}
+          # Scheduled runs bypass the layer cache and re-pull bases: a cached
+          # rebuild would reuse the old (potentially vulnerable) layers and
+          # defeat the purpose. cache-to still refreshes the cache for the
+          # week's push builds.
+          no-cache: ${{ github.event_name == 'schedule' }}
+          pull: ${{ github.event_name == 'schedule' }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-ARG PHP_VERSION=8.5
-
 ############################################
 # Base Stage
 ############################################
-FROM serversideup/php:${PHP_VERSION}-frankenphp AS base
+# Digest-pinned (supply chain): reproducible builds, and every upstream
+# rebuild of the tag lands as a reviewable Dependabot PR (tag + digest kept
+# in sync). Bumping PHP stays a deliberate move: Dockerfile, setup-php
+# (build.yml/ci.yml) and composer.json move together.
+FROM serversideup/php:8.5-frankenphp@sha256:a0f4447da7612f9bca3c982d0cf33a607cbddf828f4b96a44bfa9f6f037007b6 AS base
 
 USER root
 
@@ -61,11 +63,18 @@ COPY --link . .
 RUN composer dump-autoload --classmap-authoritative --no-dev
 
 ############################################
+# Bun Stage (alias only — the binary is copied into the app image below).
+# Declared as a FROM so Dependabot sees and bumps it: images referenced only
+# in a COPY --from are invisible to its docker ecosystem.
+############################################
+FROM oven/bun:1.3-debian@sha256:9dba1a1b43ce28c9d7931bfc4eb00feb63b0114720a0277a8f939ae4dfc9db6f AS bun
+
+############################################
 # App Image (also runs SSR via `php artisan inertia:start-ssr --runtime=bun`)
 ############################################
 FROM base AS app
 
-COPY --from=oven/bun:1.3-debian /usr/local/bin/bun /usr/local/bin/bun
+COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
 
 COPY --link --chown=33:33 --from=builder /var/www/html/vendor ./vendor
 


### PR DESCRIPTION
Replicates the pattern already live on fadogen and footeox:

- **build.yml**: weekly scheduled rebuild (Mondays 05:00 UTC, staggered after the other two repos) with `no-cache`/`pull` on scheduled runs, so base-image security fixes shipped under the same tag actually reach the image. The run produces a new `run-N` tag, so Flux Image Automation deploys it.
- **Dockerfile**: `serversideup/php:8.5-frankenphp` and `oven/bun:1.3-debian` pinned by digest; the bun reference is promoted to a `FROM ... AS bun` alias so Dependabot's docker ecosystem can see and bump it (`COPY --from=<image>` is invisible to it). `ARG PHP_VERSION` removed — bumping PHP is a deliberate multi-file change (Dockerfile + setup-php + composer.json).
- **dependabot.yml**: docker + GitHub Actions weekly (actions grouped), bun monthly (grouped). Composer is excluded on purpose: its security PRs come from repo-level Dependabot security updates, which are now enabled on this repo (they were off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)