### PR TITLE
Secure container image supply chain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
     # Weekly security rebuild (Mondays 05:00 UTC, staggered after fadogen and
     # footeox): base images ship security fixes under the SAME tag — they only
     # reach us on a fresh build. The run produces a new run-N tag, so Flux
-    # Image Automation rolls it out.
+    # Image Automation rolls its unique run-N.ATTEMPT.0 tag out.
     - cron: '0 5 * * 1'
 
 env:
@@ -18,7 +18,10 @@ env:
 
 jobs:
   build:
-    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    if: >-
+      github.event.pull_request.merged == true ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     runs-on: ${{ vars.SYSTEM_ARCH == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     permissions:
       contents: read
@@ -49,10 +52,10 @@ jobs:
       DB_USERNAME: postgres
       DB_PASSWORD: secret
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: '8.5'
           extensions: dom, curl, libxml, mbstring, zip, pdo, pdo_pgsql, bcmath, intl
@@ -60,11 +63,11 @@ jobs:
           tools: composer:v2
 
       - name: Install Composer dependencies (no-dev — matches production)
-        uses: ramsey/composer-install@v4
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
         with:
           composer-options: '--no-dev'
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
         with:
           node-version-file: .node-version
           cache: true
@@ -77,24 +80,28 @@ jobs:
           vp install
           vp run build:ssr
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.1.2
+
       - name: Build and push App image
-        uses: docker/build-push-action@v7
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
-          push: true
           target: app
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-app
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:run-${{ github.run_number }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          provenance: mode=max,version=v1
+          sbom: true
           # Scheduled runs bypass the layer cache and re-pull bases: a cached
           # rebuild would reuse the old (potentially vulnerable) layers and
           # defeat the purpose. cache-to still refreshes the cache for the
@@ -103,6 +110,30 @@ jobs:
           pull: ${{ github.event_name == 'schedule' }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
+
+      # The final tags remain invisible until the keyless signature has been
+      # verified against this exact GitHub repository and workflow identity.
+      - name: Sign, verify and publish image tags
+        shell: bash
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+          CERTIFICATE_IDENTITY: https://github.com/${{ github.workflow_ref }}
+        run: |
+          set -euo pipefail
+          image_ref="$IMAGE@$DIGEST"
+
+          cosign sign --yes "$image_ref"
+          cosign verify \
+            --certificate-identity "$CERTIFICATE_IDENTITY" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            "$image_ref" >/dev/null
+
+          docker buildx imagetools create \
+            --tag "$IMAGE:latest" \
+            --tag "$IMAGE:${{ github.sha }}-app" \
+            --tag "$IMAGE:run-${{ github.run_number }}.${{ github.run_attempt }}.0" \
+            "$image_ref"
 
       # Le Receiver Flux authentifie ce workflow avec le JWT OIDC éphémère ;
       # aucun secret webhook longue durée n'est stocké dans GitHub Actions.


### PR DESCRIPTION
## Why

Deployable image tags were published before any cryptographic verification, and the build did not explicitly produce a complete SBOM plus maximum-mode SLSA provenance.

## What changed

- push the image index by digest with BuildKit provenance `mode=max,version=v1` and an SPDX SBOM attestation;
- sign the digest keylessly with Cosign 3.1.2 with the ephemeral GitHub OIDC identity;
- verify the exact repository/workflow certificate identity;
- publish tags only after verification, then notify Flux;
- make each release tag unique per workflow attempt (`run-N.ATTEMPT.0`);
- reject deployable manual dispatches from branches other than `main`;
- pin every action used by the build workflow to an immutable commit.

## Security impact

No long-lived signing key is introduced. A failed build, signature, or identity verification cannot expose a new release tag to Flux, and a workflow rerun cannot move an earlier release tag.

## Validation

- `actionlint` (including embedded ShellCheck): passed
- `git diff --check`: passed
- repository CI: passed on the current head