### PR TITLE
Pin required CI actions by commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
         runs-on: ubuntu-24.04
 
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
               with:
                   php-version: '8.5'
                   extensions: dom, curl, libxml, mbstring, zip, pdo, pdo_sqlite, sqlite3, bcmath, intl
@@ -30,7 +30,7 @@ jobs:
                   tools: composer:v2
 
             - name: Install Composer dependencies
-              uses: ramsey/composer-install@v4
+              uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 
             - name: Prepare Laravel environment
               run: |
@@ -48,10 +48,10 @@ jobs:
         runs-on: ubuntu-24.04
 
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
               with:
                   php-version: '8.5'
                   extensions: dom, curl, libxml, mbstring, zip, pdo, pdo_sqlite, sqlite3, bcmath, intl
@@ -59,9 +59,9 @@ jobs:
                   tools: composer:v2
 
             - name: Install Composer dependencies
-              uses: ramsey/composer-install@v4
+              uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 
-            - uses: voidzero-dev/setup-vp@v1
+            - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
               with:
                   node-version-file: .node-version
                   cache: true
@@ -85,10 +85,10 @@ jobs:
         runs-on: ubuntu-24.04
 
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
               with:
                   php-version: '8.5'
                   extensions: dom, curl, libxml, mbstring, zip, pdo, pdo_sqlite, sqlite3, bcmath, intl
@@ -96,9 +96,9 @@ jobs:
                   tools: composer:v2
 
             - name: Install Composer dependencies
-              uses: ramsey/composer-install@v4
+              uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 
-            - uses: voidzero-dev/setup-vp@v1
+            - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
               with:
                   node-version-file: .node-version
                   cache: true
@@ -133,10 +133,10 @@ jobs:
         runs-on: ubuntu-24.04
 
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
               with:
                   php-version: '8.5'
                   extensions: dom, curl, libxml, mbstring, zip, pdo, pdo_sqlite, sqlite3, bcmath, intl
@@ -144,9 +144,9 @@ jobs:
                   tools: composer:v2
 
             - name: Install Composer dependencies
-              uses: ramsey/composer-install@v4
+              uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 
-            - uses: voidzero-dev/setup-vp@v1
+            - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
               with:
                   node-version-file: .node-version
                   cache: true


### PR DESCRIPTION
## Summary
- pin every third-party action used by the required pre-merge CI workflow to a full commit SHA
- keep the corresponding release version visible in comments for Renovate and auditability
- preserve the existing CI behavior and job names

## Validation
- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- verified that the required workflow contains no mutable action ref

This closes the mutable-tag supply-chain gap before the workflow becomes a mandatory `main` gate.