### PR TITLE
Remove production secrets from image builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,12 +72,22 @@ jobs:
           node-version-file: .node-version
           cache: true
 
-      - name: Load env, migrate PostgreSQL and pre-build assets
+      # Use only versioned, non-production defaults plus the isolated PostgreSQL
+      # service above. The generated APP_KEY lives for this job only.
+      - name: Prepare isolated env, migrate PostgreSQL and pre-build assets
+        env:
+          APP_ENV: production
+          APP_DEBUG: 'false'
+          CACHE_STORE: array
+          SESSION_DRIVER: array
+          QUEUE_CONNECTION: sync
+          MAIL_MAILER: log
         run: |
-          echo "${{ secrets.ENV_FILE_BASE64 }}" | base64 -d > .env
+          umask 077
+          cp .env.example .env
           php artisan key:generate --force --ansi
           php artisan migrate --force --no-interaction
-          vp install
+          vp install --frozen-lockfile
           vp run build:ssr
 
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -153,6 +163,6 @@ jobs:
               throw new Error(`Flux webhook returned HTTP ${response.status}: ${await response.text()}`)
             }
 
-      - name: Cleanup pre-build env
+      - name: Cleanup isolated build env
         if: always()
         run: rm -f .env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,14 @@ jobs:
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+            - name: Reject production env secrets in workflows
+              run: |
+                  forbidden='ENV_FILE_'
+                  if git grep -n "${forbidden}BASE64" -- .github/workflows; then
+                      echo '::error::Production runtime environments must never be CI build inputs.'
+                      exit 1
+                  fi
+
             - name: Setup PHP
               uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
               with:

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -7,6 +7,7 @@ namespace App\Http\Middleware;
 use App\Http\Resources\UserResource;
 use App\Services\I18NextTranslationsLoader;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
 use Inertia\Middleware;
 
 final class HandleInertiaRequests extends Middleware
@@ -43,7 +44,7 @@ final class HandleInertiaRequests extends Middleware
             'locale' => fn () => $locale,
             // Public Reverb application key, delivered at runtime so the
             // production value never becomes a CI build input.
-            'reverbKey' => (string) config('broadcasting.connections.reverb.key'),
+            'reverbKey' => Config::string('broadcasting.connections.reverb.key'),
             'translations' => ! $request->inertia() ? [
                 $locale => [
                     'translation' => $this->translationsLoader->loadTranslations($locale),

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -41,6 +41,9 @@ final class HandleInertiaRequests extends Middleware
                 'user' => $request->user() ? new UserResource($request->user()) : null,
             ],
             'locale' => fn () => $locale,
+            // Public Reverb application key, delivered at runtime so the
+            // production value never becomes a CI build input.
+            'reverbKey' => (string) config('broadcasting.connections.reverb.key'),
             'translations' => ! $request->inertia() ? [
                 $locale => [
                     'translation' => $this->translationsLoader->loadTranslations($locale),

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -11,10 +11,6 @@ import AppLayout from '@/layouts/app-layout';
 import AuthLayout from '@/layouts/auth-layout';
 import { initI18n, setLocale } from './i18n';
 
-configureEcho({
-    broadcaster: import.meta.env.SSR ? 'null' : 'reverb',
-});
-
 const appName = import.meta.env.VITE_APP_NAME || 'Ping CRM';
 
 void createInertiaApp({
@@ -31,6 +27,20 @@ void createInertiaApp({
         return AppLayout;
     },
     setup: ({ el, App, props }) => {
+        if (import.meta.env.SSR) {
+            configureEcho({ broadcaster: 'null' });
+        } else {
+            configureEcho({
+                broadcaster: 'reverb',
+                key: props.initialPage.props.reverbKey,
+                wsHost: window.location.hostname,
+                wsPort: 443,
+                wssPort: 443,
+                forceTLS: true,
+                enabledTransports: ['ws', 'wss'],
+            });
+        }
+
         const locale = props.initialPage.props.locale;
         const i18nInstance = initI18n(locale, props.initialPage.props.translations ?? {});
         setLocale(locale);

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -19,4 +19,5 @@ export interface NavItem {
 
 export type SharedData = Omit<Inertia.SharedData, 'flash'> & {
     flash: FlashMessages;
+    reverbKey: string;
 };

--- a/tests/Feature/ReverbExampleTest.php
+++ b/tests/Feature/ReverbExampleTest.php
@@ -13,10 +13,14 @@ beforeEach(function () {
 });
 
 it('renders the reverb example page for authenticated users', function () {
+    config()->set('broadcasting.connections.reverb.key', 'runtime-public-key');
+
     $this->actingAs($this->user)
         ->get('/reverb')
         ->assertSuccessful()
-        ->assertInertia(fn (Assert $assert) => $assert->component('reverb-example'));
+        ->assertInertia(fn (Assert $assert) => $assert
+            ->component('reverb-example')
+            ->where('reverbKey', 'runtime-public-key'));
 });
 
 it('dispatches the reverb job with a delay when a valid uuid is posted', function () {


### PR DESCRIPTION
## What changed

- build and migrate against the isolated PostgreSQL service using the versioned `.env.example`;
- generate a job-local Laravel key and isolate cache, session, queue and mail;
- deliver the public Reverb application key at runtime through Inertia and derive the WebSocket host from the current origin;
- remove all build-time use of `ENV_FILE_BASE64`.

## Security outcome

CI no longer receives the production environment, while Reverb remains correctly configured at runtime. Digest-first push, keyless Cosign signature, provenance, SBOM and OIDC Flux notification are unchanged.

## Validation

- `actionlint .github/workflows/*.yml`
- `git diff --check`
- `vp run types`
- `vp run lint:check`
- `vp run format:check`
- focused feature assertion for the runtime Reverb key