### PR TITLE
Attest image provenance with SLSA v1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,22 +121,42 @@ jobs:
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
 
-      # The final tags remain invisible until the keyless signature has been
-      # verified against this exact GitHub repository and workflow identity.
-      - name: Sign, verify and publish image tags
+      # Keep the plain OCI 1.1 signature and add a signed SLSA v1 provenance
+      # bundle that policy-controller can enforce natively.
+      - name: Sign, attest, verify and publish image tags
         shell: bash
         env:
           IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           DIGEST: ${{ steps.build.outputs.digest }}
           CERTIFICATE_IDENTITY: https://github.com/${{ github.workflow_ref }}
+          EXPECTED_BUILDER_ID: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
         run: |
           set -euo pipefail
           image_ref="$IMAGE@$DIGEST"
+          provenance_path="$RUNNER_TEMP/provenance-${DIGEST#sha256:}.json"
+
+          docker buildx imagetools inspect "$image_ref" \
+            --format '{{ json .Provenance.SLSA }}' > "$provenance_path"
+          jq -e --arg expected_builder "$EXPECTED_BUILDER_ID" '
+            (.buildDefinition.buildType | type == "string" and length > 0) and
+            (.runDetails.builder.id == $expected_builder) and
+            (.runDetails.metadata.finishedOn | type == "string" and length > 0)
+          ' "$provenance_path" >/dev/null
 
           cosign sign --yes "$image_ref"
           cosign verify \
             --certificate-identity "$CERTIFICATE_IDENTITY" \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            "$image_ref" >/dev/null
+
+          cosign attest --yes \
+            --predicate "$provenance_path" \
+            --type slsaprovenance1 \
+            "$image_ref"
+          cosign verify-attestation \
+            --certificate-identity "$CERTIFICATE_IDENTITY" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            --type slsaprovenance1 \
             "$image_ref" >/dev/null
 
           docker buildx imagetools create \


### PR DESCRIPTION
## Résumé\n- extrait la provenance BuildKit SLSA v1 attachée au digest immuable\n- vérifie qu’elle provient du run GitHub exact\n- signe cette provenance keyless dans un bundle OCI 1.1 Cosign 3\n- vérifie signature simple et attestation avant de publier les tags visibles par Flux\n\n## Pourquoi\npolicy-controller prend en charge le bundle OCI 1.1 pour les attestations mais pas encore pour les signatures simples. Ce chemin reste moderne et évite tout stockage legacy.\n\n## Validation\n- actionlint\n- YAML parse\n- expression jq testée contre une provenance BuildKit SLSA v1 réelle