### PR TITLE
ci: pin PostgreSQL service image digest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,9 @@ jobs:
       # generated TS types match runtime PDO behaviour (column types are engine
       # specific).
       postgres:
-        image: postgres:18
+        # Tag lisible + digest multi-architecture immuable ; Renovate suit les
+        # reconstructions de postgres:18 via le preset docker:pinDigests.
+        image: postgres:18@sha256:3a82e1f56c8f0f5616a11103ac3d47e632c3938698946a7ad26da0df1334744a
         env:
           POSTGRES_PASSWORD: secret
           POSTGRES_DB: pingcrm

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>fouteox/renovate-config",
-    "github>fouteox/renovate-config:apps"
+    "github>fouteox/renovate-config:apps",
+    "docker:pinDigests"
   ]
 }


### PR DESCRIPTION
## Résumé

- épingle le service PostgreSQL du workflow de build sur le digest exact de l'index multi-architecture `postgres:18`
- conserve le tag lisible afin que Renovate suive les reconstructions de l'image officielle
- active le preset officiel `docker:pinDigests` pour que les futurs changements de digest passent par PR

## Risque corrigé

Le tag `postgres:18` est mutable. Deux exécutions du même commit pouvaient donc utiliser des octets différents sans changement versionné du dépôt. La référence `tag@sha256` rend le build reproductible tout en gardant les mises à jour visibles et automatisées par Renovate.

## Validation

- `actionlint .github/workflows/build.yml`
- `renovate-config-validator renovate.json` avec Renovate 43.272.8
- digest courant résolu depuis Docker Hub et manifeste OCI multi-architecture relu par `docker buildx imagetools inspect`
- `git diff --check`
