### PR TITLE
Use the configured runtime Reverb endpoint

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -42,9 +42,14 @@ final class HandleInertiaRequests extends Middleware
                 'user' => $request->user() ? new UserResource($request->user()) : null,
             ],
             'locale' => fn () => $locale,
-            // Public Reverb application key, delivered at runtime so the
-            // production value never becomes a CI build input.
-            'reverbKey' => Config::string('broadcasting.connections.reverb.key'),
+            // Public Reverb endpoint, delivered at runtime so production
+            // values never become CI build inputs.
+            'reverb' => [
+                'key' => Config::string('broadcasting.connections.reverb.key'),
+                'host' => Config::string('broadcasting.connections.reverb.options.host'),
+                'port' => (int) config('broadcasting.connections.reverb.options.port'),
+                'scheme' => Config::string('broadcasting.connections.reverb.options.scheme'),
+            ],
             'translations' => ! $request->inertia() ? [
                 $locale => [
                     'translation' => $this->translationsLoader->loadTranslations($locale),

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -30,13 +30,15 @@ void createInertiaApp({
         if (import.meta.env.SSR) {
             configureEcho({ broadcaster: 'null' });
         } else {
+            const reverb = props.initialPage.props.reverb;
+
             configureEcho({
                 broadcaster: 'reverb',
-                key: props.initialPage.props.reverbKey,
-                wsHost: window.location.hostname,
-                wsPort: 443,
-                wssPort: 443,
-                forceTLS: true,
+                key: reverb.key,
+                wsHost: reverb.host,
+                wsPort: reverb.port,
+                wssPort: reverb.port,
+                forceTLS: reverb.scheme === 'https',
                 enabledTransports: ['ws', 'wss'],
             });
         }

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -19,5 +19,10 @@ export interface NavItem {
 
 export type SharedData = Omit<Inertia.SharedData, 'flash'> & {
     flash: FlashMessages;
-    reverbKey: string;
+    reverb: {
+        key: string;
+        host: string;
+        port: number;
+        scheme: string;
+    };
 };

--- a/tests/Feature/ReverbExampleTest.php
+++ b/tests/Feature/ReverbExampleTest.php
@@ -13,14 +13,24 @@ beforeEach(function () {
 });
 
 it('renders the reverb example page for authenticated users', function () {
-    config()->set('broadcasting.connections.reverb.key', 'runtime-public-key');
+    config()->set([
+        'broadcasting.connections.reverb.key' => 'runtime-public-key',
+        'broadcasting.connections.reverb.options.host' => 'reverb.example.test',
+        'broadcasting.connections.reverb.options.port' => '8443',
+        'broadcasting.connections.reverb.options.scheme' => 'https',
+    ]);
 
     $this->actingAs($this->user)
         ->get('/reverb')
         ->assertSuccessful()
         ->assertInertia(fn (Assert $assert) => $assert
             ->component('reverb-example')
-            ->where('reverbKey', 'runtime-public-key'));
+            ->where('reverb', [
+                'key' => 'runtime-public-key',
+                'host' => 'reverb.example.test',
+                'port' => 8443,
+                'scheme' => 'https',
+            ]));
 });
 
 it('dispatches the reverb job with a delay when a valid uuid is posted', function () {


### PR DESCRIPTION
## What changed

- Share the public Reverb key, host, port, and scheme through runtime Inertia props.
- Configure Echo from the Laravel runtime endpoint instead of the page hostname and hard-coded TLS port.
- Extend the Reverb feature test to cover the complete endpoint.

## Why

Reverb can be served from a host, port, or scheme different from the application page. Those deployment values must remain runtime configuration rather than assumptions baked into the frontend.

## Validation

- Pest: 5 tests passed, 20 assertions
- TypeScript: `tsc --noEmit`
- Vite+ lint and format checks
- Pint
- `git diff --check`