### PR TITLE
Type the runtime Reverb port configuration

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -47,7 +47,7 @@ final class HandleInertiaRequests extends Middleware
             'reverb' => [
                 'key' => Config::string('broadcasting.connections.reverb.key'),
                 'host' => Config::string('broadcasting.connections.reverb.options.host'),
-                'port' => (int) config('broadcasting.connections.reverb.options.port'),
+                'port' => Config::integer('broadcasting.connections.reverb.options.port'),
                 'scheme' => Config::string('broadcasting.connections.reverb.options.scheme'),
             ],
             'translations' => ! $request->inertia() ? [

--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -39,7 +39,7 @@ return [
             'app_id' => env('REVERB_APP_ID'),
             'options' => [
                 'host' => env('REVERB_HOST'),
-                'port' => env('REVERB_PORT', 443),
+                'port' => (int) env('REVERB_PORT', 443),
                 'scheme' => env('REVERB_SCHEME', 'https'),
                 'useTLS' => env('REVERB_SCHEME', 'https') === 'https',
             ],

--- a/tests/Feature/ReverbExampleTest.php
+++ b/tests/Feature/ReverbExampleTest.php
@@ -16,7 +16,7 @@ it('renders the reverb example page for authenticated users', function () {
     config()->set([
         'broadcasting.connections.reverb.key' => 'runtime-public-key',
         'broadcasting.connections.reverb.options.host' => 'reverb.example.test',
-        'broadcasting.connections.reverb.options.port' => '8443',
+        'broadcasting.connections.reverb.options.port' => 8443,
         'broadcasting.connections.reverb.options.scheme' => 'https',
     ]);
 


### PR DESCRIPTION
## Summary

- cast `REVERB_PORT` at the configuration boundary
- read the runtime port through Laravel's typed `Config::integer()` API
- keep the Inertia contract test explicitly integer-typed

## Validation

- `vendor/bin/pint --test app/Http/Middleware/HandleInertiaRequests.php config/broadcasting.php tests/Feature/ReverbExampleTest.php`
- `vendor/bin/pest tests/Feature/ReverbExampleTest.php --compact` (5 tests, 20 assertions)

This is the PingCRM parity follow-up to the PHPStan finding surfaced by Footeox PR #438.