### PR TITLE
Add GitHub image attestations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     runs-on: ${{ vars.SYSTEM_ARCH == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     permissions:
+      attestations: write
       contents: read
       id-token: write
       packages: write
@@ -122,6 +123,30 @@ jobs:
           pull: ${{ github.event_name == 'schedule' }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
+
+      # Public repositories can use GitHub's hosted attestation service. It
+      # provides Build Level 2 provenance in addition to the BuildKit/Cosign
+      # bundle retained below for the current cluster admission policy.
+      - name: Attest image with GitHub
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Verify GitHub artifact attestation
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          gh attestation verify "oci://$IMAGE@$DIGEST" \
+            --repo "$GITHUB_REPOSITORY" \
+            --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/build.yml" \
+            --deny-self-hosted-runners \
+            --bundle-from-oci
 
       # Keep the plain OCI 1.1 signature and add a signed SLSA v1 provenance
       # bundle that policy-controller can enforce natively.


### PR DESCRIPTION
## What changed

- enable the `attestations: write` job permission
- attest the pushed image digest with SHA-pinned `actions/attest` v4.2.0
- publish the bundle as an OCI referrer
- verify it from the registry with the exact signer workflow and reject self-hosted builders

## Why

The public repository can use GitHub's hosted artifact attestation service to add Build Level 2 provenance alongside the existing BuildKit/Cosign policy bundle.

## Validation

- `actionlint .github/workflows/build.yml`
- Renovate 43.275.2 strict validation
- `git diff --check`