### PR TITLE
Strip the file capability from the frankenphp binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,4 +89,12 @@ RUN mkdir -p \
     bootstrap/cache \
     && chown -R www-data:www-data storage bootstrap/cache
 
+# The serversideup base grants cap_net_bind_service to frankenphp (bind <1024).
+# Octane listens on 8000, and the file capability makes execve fail with
+# "Operation not permitted" under no_new_privs (PSS restricted,
+# allowPrivilegeEscalation: false). A plain cp does not preserve xattrs,
+# which strips the capability without needing libcap2-bin.
+RUN cp /usr/local/bin/frankenphp /tmp/frankenphp \
+    && mv /tmp/frankenphp /usr/local/bin/frankenphp
+
 USER www-data


### PR DESCRIPTION
Companion of gitops#44/gitops#45 (PSS-restricted rollout).

serversideup sets `cap_net_bind_service=+ep` on `/usr/local/bin/frankenphp`. Octane binds 8000 so the capability is useless here, and it actively breaks the hardened pod spec: under `allowPrivilegeEscalation: false` (no_new_privs) the kernel refuses to exec a binary carrying file capabilities → CrashLoopBackOff on `pingcrm-app` (only that Deployment execs frankenphp).

Fix: re-copy the binary in the final stage — `cp` drops xattrs, so the capability is stripped without installing `libcap2-bin`. No behavior change: the server keeps binding 8000 as `www-data`.

Once this image is deployed by Image Automation, gitops `apps/pingcrm/app.yaml` reverts the temporary `allowPrivilegeEscalation: true` (see the TODO comment there) and the whole namespace becomes PSS-restricted-compliant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)