### PR TITLE
Pin vite-plus to 0.2.5 instead of the floating latest tag

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -37,8 +37,8 @@
         "@laravel/vite-plugin-wayfinder": "^0.1.7",
         "concurrently": "^10.0.3",
         "playwright": "^1.61.1",
-        "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-        "vite-plus": "latest",
+        "vite": "npm:@voidzero-dev/vite-plus-core@0.2.5",
+        "vite-plus": "0.2.5",
       },
     },
   },
@@ -46,7 +46,7 @@
     "@tailwindcss/oxide",
   ],
   "overrides": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
+    "vite": "npm:@voidzero-dev/vite-plus-core@0.2.5",
   },
   "packages": {
     "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
         "@laravel/vite-plugin-wayfinder": "^0.1.7",
         "concurrently": "^10.0.3",
         "playwright": "^1.61.1",
-        "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-        "vite-plus": "latest"
+        "vite": "npm:@voidzero-dev/vite-plus-core@0.2.5",
+        "vite-plus": "0.2.5"
     },
     "dependencies": {
         "@base-ui/react": "^1.6.0",
@@ -49,7 +49,7 @@
         "uuid": "^14.0.1"
     },
     "overrides": {
-        "vite": "npm:@voidzero-dev/vite-plus-core@latest"
+        "vite": "npm:@voidzero-dev/vite-plus-core@0.2.5"
     },
     "trustedDependencies": [
         "@tailwindcss/oxide"


### PR DESCRIPTION
## Résumé
- Épingle \`vite-plus\` / \`@voidzero-dev/vite-plus-core\` à **0.2.5** (au lieu de \`latest\`) dans les devDependencies **et** les overrides.
- Le lockfile résolvait déjà 0.2.5 : seuls les specifiers changent (diff bun.lock = 3 lignes).

## Contexte
Constat de l'audit SOTA du 22/07 : la toolchain front était le seul maillon non épinglé de la supply chain (actions par SHA, images par digest partout ailleurs). fadogen épingle 0.2.5, footeox 0.2.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)