### PR TITLE
Verify ServerSideUp digests and the production image

### DIFF
--- a/.github/scripts/compare-base-vulnerabilities.sh
+++ b/.github/scripts/compare-base-vulnerabilities.sh
@@ -5,8 +5,15 @@ set -Eeuo pipefail
 extract_image_ref() {
     awk '
         $1 == "FROM" && $2 ~ /^serversideup\/php:[^@[:space:]]+@sha256:[0-9a-f]{64}$/ {
-            print $2
-            exit
+            references[++count] = $2
+        }
+        END {
+            if (count != 1) {
+                printf "Expected exactly one digest-pinned ServerSideUp base in %s, found %d.\n", FILENAME, count > "/dev/stderr"
+                exit 1
+            }
+
+            print references[1]
         }
     ' "$1"
 }

--- a/.github/scripts/compare-base-vulnerabilities.sh
+++ b/.github/scripts/compare-base-vulnerabilities.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+extract_image_ref() {
+    awk '
+        $1 == "FROM" && $2 ~ /^serversideup\/php:[^@[:space:]]+@sha256:[0-9a-f]{64}$/ {
+            print $2
+            exit
+        }
+    ' "$1"
+}
+
+current_ref=${CURRENT_IMAGE_REF:-}
+previous_ref=${PREVIOUS_IMAGE_REF:-}
+work_dir=$(mktemp -d)
+cache_dir=${TRIVY_CACHE_DIR:-"$work_dir/trivy-cache"}
+
+cleanup() {
+    rm -rf "$work_dir"
+}
+
+trap cleanup EXIT
+
+if [[ -z "$current_ref" ]]; then
+    current_ref=$(extract_image_ref Dockerfile)
+fi
+
+if [[ -z "$previous_ref" ]]; then
+    : "${BASE_SHA:?BASE_SHA is required when PREVIOUS_IMAGE_REF is not set.}"
+    : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required when PREVIOUS_IMAGE_REF is not set.}"
+
+    previous_dockerfile="$work_dir/previous.Dockerfile"
+    gh api "repos/$GITHUB_REPOSITORY/contents/Dockerfile?ref=$BASE_SHA" \
+        --jq .content | base64 --decode > "$previous_dockerfile"
+    previous_ref=$(extract_image_ref "$previous_dockerfile")
+fi
+
+if [[ -z "$current_ref" || -z "$previous_ref" ]]; then
+    echo "Could not resolve both current and previous ServerSideUp image references." >&2
+    exit 1
+fi
+
+if [[ "$current_ref" == "$previous_ref" ]]; then
+    echo "ServerSideUp base image is unchanged; vulnerability delta scan skipped."
+    exit 0
+fi
+
+for architecture in amd64 arm64; do
+    previous_report="$work_dir/previous-$architecture.json"
+    current_report="$work_dir/current-$architecture.json"
+    introduced_report="$work_dir/introduced-$architecture.json"
+
+    trivy image \
+        --cache-dir "$cache_dir" \
+        --quiet \
+        --scanners vuln \
+        --severity HIGH,CRITICAL \
+        --ignore-unfixed \
+        --format json \
+        --output "$previous_report" \
+        --platform "linux/$architecture" \
+        "$previous_ref"
+
+    trivy image \
+        --cache-dir "$cache_dir" \
+        --quiet \
+        --scanners vuln \
+        --severity HIGH,CRITICAL \
+        --ignore-unfixed \
+        --format json \
+        --output "$current_report" \
+        --platform "linux/$architecture" \
+        "$current_ref"
+
+    jq -n \
+        --slurpfile previous "$previous_report" \
+        --slurpfile current "$current_report" \
+        '
+        def vulnerabilities($report):
+            [
+                $report.Results[]?.Vulnerabilities[]?
+                | {
+                    id: .VulnerabilityID,
+                    package: .PkgName,
+                    severity: .Severity,
+                    installed: .InstalledVersion,
+                    fixed: .FixedVersion
+                }
+            ]
+            | unique_by(.id, .package);
+
+        vulnerabilities($previous[0]) as $previous_vulnerabilities
+        | vulnerabilities($current[0])
+        | map(
+            . as $candidate
+            | select(
+                (
+                    $previous_vulnerabilities
+                    | any(.id == $candidate.id and .package == $candidate.package)
+                )
+                | not
+            )
+        )
+        ' > "$introduced_report"
+
+    if ! jq -e 'length == 0' "$introduced_report" >/dev/null; then
+        echo "::error title=New fixable HIGH/CRITICAL vulnerabilities::linux/$architecture introduces vulnerabilities absent from the previous digest."
+        jq -r '.[] | "\(.severity) \(.id) \(.package) \(.installed) -> \(.fixed)"' "$introduced_report"
+        exit 1
+    fi
+
+    echo "No newly introduced fixable HIGH/CRITICAL vulnerability on linux/$architecture."
+done

--- a/.github/scripts/smoke-production-image.sh
+++ b/.github/scripts/smoke-production-image.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <image-reference>" >&2
+    exit 64
+fi
+
+image_ref=$1
+expected_architecture=${EXPECTED_ARCHITECTURE:-amd64}
+actual_architecture=$(docker image inspect --format '{{.Architecture}}' "$image_ref")
+
+if [[ "$actual_architecture" != "$expected_architecture" ]]; then
+    echo "Expected image architecture $expected_architecture, got $actual_architecture." >&2
+    exit 1
+fi
+
+docker run --rm --entrypoint sh "$image_ref" -euc '
+    bun --version
+    test -s public/build/manifest.json
+    find bootstrap/ssr -maxdepth 1 -type f -name "*.js" -print -quit | grep -q .
+    php -r '\''
+        foreach (["bcmath", "intl", "pdo_pgsql"] as $extension) {
+            if (! extension_loaded($extension)) {
+                fwrite(STDERR, "Missing PHP extension: {$extension}\n");
+                exit(1);
+            }
+        }
+    '\''
+'
+
+runtime_env=(
+    --env APP_ENV=production
+    --env APP_DEBUG=false
+    --env APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+    --env APP_URL=http://127.0.0.1:8080
+    --env CACHE_STORE=array
+    --env DB_CONNECTION=pgsql
+    --env DB_HOST=127.0.0.1
+    --env DB_PORT=5432
+    --env DB_DATABASE=pingcrm_image_smoke
+    --env DB_USERNAME=postgres
+    --env DB_PASSWORD=secret
+    --env LOG_CHANNEL=stderr
+    --env MAIL_MAILER=log
+    --env QUEUE_CONNECTION=sync
+    --env SESSION_DRIVER=array
+)
+
+docker run --rm --network host \
+    "${runtime_env[@]}" \
+    --entrypoint php \
+    "$image_ref" \
+    artisan migrate --force --no-interaction
+
+container_id=''
+
+cleanup() {
+    if [[ -n "$container_id" ]]; then
+        docker rm --force "$container_id" >/dev/null 2>&1 || true
+    fi
+}
+
+trap cleanup EXIT
+
+container_id=$(docker run --detach --network host \
+    "${runtime_env[@]}" \
+    --env AUTORUN_ENABLED=false \
+    --env HEALTHCHECK_PATH=/up \
+    --env SSL_MODE=off \
+    "$image_ref")
+
+health=starting
+
+for _ in {1..30}; do
+    if [[ $(docker inspect --format '{{.State.Running}}' "$container_id") != true ]]; then
+        docker logs "$container_id" >&2
+        echo "Production image exited before becoming healthy." >&2
+        exit 1
+    fi
+
+    health=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}missing{{end}}' "$container_id")
+
+    if [[ "$health" == healthy ]]; then
+        break
+    fi
+
+    if [[ "$health" == unhealthy || "$health" == missing ]]; then
+        docker logs "$container_id" >&2
+        echo "Production image health status: $health" >&2
+        exit 1
+    fi
+
+    sleep 2
+done
+
+if [[ "$health" != healthy ]]; then
+    docker logs "$container_id" >&2
+    echo "Production image did not become healthy within 60 seconds." >&2
+    exit 1
+fi
+
+curl --fail --silent --show-error http://127.0.0.1:8080/up >/dev/null

--- a/.github/scripts/verify-serversideup-base.sh
+++ b/.github/scripts/verify-serversideup-base.sh
@@ -8,8 +8,15 @@ image_ref=${IMAGE_REF:-}
 if [[ -z "$image_ref" ]]; then
     image_ref=$(awk '
         $1 == "FROM" && $2 ~ /^serversideup\/php:[^@[:space:]]+@sha256:[0-9a-f]{64}$/ {
-            print $2
-            exit
+            references[++count] = $2
+        }
+        END {
+            if (count != 1) {
+                printf "Expected exactly one digest-pinned ServerSideUp base, found %d.\n", count > "/dev/stderr"
+                exit 1
+            }
+
+            print references[1]
         }
     ' "$dockerfile")
 fi

--- a/.github/scripts/verify-serversideup-base.sh
+++ b/.github/scripts/verify-serversideup-base.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+dockerfile=${1:-Dockerfile}
+image_ref=${IMAGE_REF:-}
+
+if [[ -z "$image_ref" ]]; then
+    image_ref=$(awk '
+        $1 == "FROM" && $2 ~ /^serversideup\/php:[^@[:space:]]+@sha256:[0-9a-f]{64}$/ {
+            print $2
+            exit
+        }
+    ' "$dockerfile")
+fi
+
+if [[ ! "$image_ref" =~ ^serversideup/php:([0-9]+\.[0-9]+\.[0-9]+)-frankenphp@(sha256:[0-9a-f]{64})$ ]]; then
+    echo "Expected one digest-pinned serversideup/php:<version>-frankenphp base in $dockerfile." >&2
+    exit 1
+fi
+
+php_version=${BASH_REMATCH[1]}
+declared_index_digest=${BASH_REMATCH[2]}
+repository=serversideup/php
+work_dir=$(mktemp -d)
+
+cleanup() {
+    rm -rf "$work_dir"
+}
+
+trap cleanup EXIT
+
+index_file="$work_dir/index.json"
+docker buildx imagetools inspect "$image_ref" --raw > "$index_file"
+
+actual_index_digest="sha256:$(sha256sum "$index_file" | awk '{ print $1 }')"
+
+if [[ "$actual_index_digest" != "$declared_index_digest" ]]; then
+    echo "Index digest mismatch: expected $declared_index_digest, got $actual_index_digest." >&2
+    exit 1
+fi
+
+jq -e '
+    .mediaType == "application/vnd.oci.image.index.v1+json"
+    and ([.manifests[] | select(.platform.os == "linux" and (.platform.architecture == "amd64" or .platform.architecture == "arm64"))] | length == 2)
+' "$index_file" >/dev/null
+
+registry_token=$(curl \
+    --fail \
+    --silent \
+    --show-error \
+    --location \
+    --retry 3 \
+    --retry-all-errors \
+    --get \
+    --data-urlencode service=registry.docker.io \
+    --data-urlencode "scope=repository:$repository:pull" \
+    https://auth.docker.io/token | jq -er .token)
+
+for architecture in amd64 arm64; do
+    platform_digest=$(jq -er \
+        --arg architecture "$architecture" \
+        '.manifests[]
+            | select(.platform.os == "linux" and .platform.architecture == $architecture)
+            | .digest' \
+        "$index_file")
+
+    attestation_digest=$(jq -er \
+        --arg platform_digest "$platform_digest" \
+        '.manifests[]
+            | select(
+                .annotations["vnd.docker.reference.type"] == "attestation-manifest"
+                and .annotations["vnd.docker.reference.digest"] == $platform_digest
+            )
+            | .digest' \
+        "$index_file")
+
+    attestation_file="$work_dir/attestation-$architecture.json"
+    docker buildx imagetools inspect "$repository@$attestation_digest" --raw > "$attestation_file"
+
+    actual_attestation_digest="sha256:$(sha256sum "$attestation_file" | awk '{ print $1 }')"
+
+    if [[ "$actual_attestation_digest" != "$attestation_digest" ]]; then
+        echo "Attestation manifest digest mismatch for linux/$architecture." >&2
+        exit 1
+    fi
+
+    provenance_digest=$(jq -er '
+        .layers[]
+        | select(
+            .mediaType == "application/vnd.in-toto+json"
+            and .annotations["in-toto.io/predicate-type"] == "https://slsa.dev/provenance/v0.2"
+        )
+        | .digest
+    ' "$attestation_file")
+
+    provenance_file="$work_dir/provenance-$architecture.json"
+    curl \
+        --fail \
+        --silent \
+        --show-error \
+        --location \
+        --retry 3 \
+        --retry-all-errors \
+        --header "Authorization: Bearer $registry_token" \
+        "https://registry-1.docker.io/v2/$repository/blobs/$provenance_digest" \
+        --output "$provenance_file"
+
+    actual_provenance_digest="sha256:$(sha256sum "$provenance_file" | awk '{ print $1 }')"
+
+    if [[ "$actual_provenance_digest" != "$provenance_digest" ]]; then
+        echo "Provenance blob digest mismatch for linux/$architecture." >&2
+        exit 1
+    fi
+
+    platform_digest_hex=${platform_digest#sha256:}
+
+    jq -e \
+        --arg architecture "$architecture" \
+        --arg php_version "$php_version" \
+        --arg platform_digest "$platform_digest_hex" \
+        '
+        ._type == "https://in-toto.io/Statement/v0.1"
+        and .predicateType == "https://slsa.dev/provenance/v0.2"
+        and any(.subject[]?; .digest.sha256 == $platform_digest)
+        and (.predicate.builder.id | test("^https://github\\.com/serversideup/docker-php/actions/runs/[0-9]+$"))
+        and .predicate.buildType == "https://mobyproject.org/buildkit@v1"
+        and (.predicate.invocation.configSource.uri | test("^https://github\\.com/serversideup/docker-php\\.git#[0-9a-f]{40}$"))
+        and (.predicate.invocation.configSource.digest.sha1 | test("^[0-9a-f]{40}$"))
+        and .predicate.invocation.configSource.entryPoint == "src/variations/frankenphp/Dockerfile"
+        and .predicate.invocation.parameters.args["build-arg:PHP_VERSION"] == $php_version
+        and .predicate.invocation.parameters.args["build-arg:PHP_VARIATION"] == "frankenphp"
+        and .predicate.invocation.environment.platform == ("linux/" + $architecture)
+        and .predicate.metadata.completeness.parameters == true
+        and .predicate.metadata.completeness.environment == true
+        and .predicate.metadata.completeness.materials == true
+        and (.predicate.materials | length > 0)
+        ' \
+        "$provenance_file" >/dev/null
+
+    builder_id=$(jq -er .predicate.builder.id "$provenance_file")
+    run_id=${builder_id##*/}
+    source_uri=$(jq -er .predicate.invocation.configSource.uri "$provenance_file")
+    source_sha=${source_uri##*#}
+    declared_source_sha=$(jq -er .predicate.invocation.configSource.digest.sha1 "$provenance_file")
+
+    if [[ "$source_sha" != "$declared_source_sha" ]]; then
+        echo "Source commit mismatch in linux/$architecture provenance." >&2
+        exit 1
+    fi
+
+    run_file="$work_dir/run-$architecture.json"
+    gh api "repos/serversideup/docker-php/actions/runs/$run_id" > "$run_file"
+
+    jq -e \
+        --arg source_sha "$source_sha" \
+        '
+        .status == "completed"
+        and .conclusion == "success"
+        and .head_sha == $source_sha
+        and .repository.full_name == "serversideup/docker-php"
+        and .head_repository.full_name == "serversideup/docker-php"
+        and .path == ".github/workflows/action_publish-images-production.yml"
+        and (.event == "schedule" or .event == "release" or .event == "workflow_dispatch")
+        ' \
+        "$run_file" >/dev/null
+
+    echo "Verified linux/$architecture provenance against ServerSideUp run $run_id."
+done
+
+echo "Verified pinned ServerSideUp index $declared_index_digest."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,61 @@ env:
     FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+    base-image-policy:
+        name: Validate ServerSideUp base image
+        runs-on: ubuntu-24.04
+        timeout-minutes: 20
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  persist-credentials: false
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+            - name: Verify pinned ServerSideUp provenance
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: .github/scripts/verify-serversideup-base.sh
+
+            - name: Install checksum-verified Trivy
+              env:
+                  TRIVY_VERSION: 0.72.0
+              run: |
+                  case "$RUNNER_ARCH" in
+                    X64)
+                      archive="trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+                      checksum=bbb64b9695866ce4a7a8f5c9592002c5961cab378577fa3f8a040df362b9b2ea
+                      ;;
+                    ARM64)
+                      archive="trivy_${TRIVY_VERSION}_Linux-ARM64.tar.gz"
+                      checksum=2ca2c023109c2db6b2b77366b6717291452d4531167377d95c79547f0c8e3467
+                      ;;
+                    *)
+                      echo "Unsupported runner architecture: $RUNNER_ARCH" >&2
+                      exit 1
+                      ;;
+                  esac
+
+                  archive_path="$RUNNER_TEMP/$archive"
+                  curl --fail --silent --show-error --location \
+                    --retry 3 --retry-all-errors \
+                    "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/${archive}" \
+                    --output "$archive_path"
+                  printf '%s  %s\n' "$checksum" "$archive_path" | sha256sum --check -
+                  tar -xzf "$archive_path" -C "$RUNNER_TEMP" trivy
+                  echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
+                  "$RUNNER_TEMP/trivy" --version
+
+            - name: Reject newly introduced fixable HIGH/CRITICAL vulnerabilities
+              env:
+                  BASE_SHA: ${{ github.event.pull_request.base.sha }}
+                  GH_TOKEN: ${{ github.token }}
+                  TRIVY_CACHE_DIR: ${{ runner.temp }}/trivy-cache
+              run: .github/scripts/compare-base-vulnerabilities.sh
+
     php:
         name: PHP (Pint + Pest)
         runs-on: ubuntu-24.04
@@ -174,6 +229,92 @@ jobs:
 
             - name: Build production bundle
               run: vp run build
+
+    production-image:
+        name: Validate production image
+        runs-on: ${{ vars.SYSTEM_ARCH == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+        timeout-minutes: 30
+
+        services:
+            postgres:
+                image: postgres:18@sha256:3a82e1f56c8f0f5616a11103ac3d47e632c3938698946a7ad26da0df1334744a
+                env:
+                    POSTGRES_PASSWORD: secret
+                    POSTGRES_DB: pingcrm_image_smoke
+                ports:
+                    - 5432:5432
+                options: >-
+                    --health-cmd="pg_isready -U postgres -d pingcrm_image_smoke"
+                    --health-interval=5s
+                    --health-timeout=5s
+                    --health-retries=10
+
+        env:
+            DB_CONNECTION: pgsql
+            DB_HOST: 127.0.0.1
+            DB_PORT: '5432'
+            DB_DATABASE: pingcrm_image_smoke
+            DB_USERNAME: postgres
+            DB_PASSWORD: secret
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  persist-credentials: false
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+              with:
+                  php-version: '8.5'
+                  extensions: dom, curl, libxml, mbstring, zip, pdo, pdo_pgsql, bcmath, intl
+                  coverage: none
+                  tools: composer:v2
+
+            - name: Install production Composer dependencies
+              uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
+              with:
+                  composer-options: '--no-dev'
+                  ignore-cache: '1'
+
+            - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
+              with:
+                  node-version-file: .node-version
+                  cache: true
+
+            - name: Prepare isolated PostgreSQL environment and assets
+              env:
+                  APP_ENV: production
+                  APP_DEBUG: 'false'
+                  CACHE_STORE: array
+                  SESSION_DRIVER: array
+                  QUEUE_CONNECTION: sync
+                  MAIL_MAILER: log
+              run: |
+                  umask 077
+                  cp .env.example .env
+                  php artisan key:generate --force --ansi
+                  php artisan migrate --force --no-interaction
+                  vp install --frozen-lockfile
+                  vp run build:ssr
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+            - name: Build production image locally
+              uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+              with:
+                  context: .
+                  target: app
+                  load: true
+                  tags: pingcrm-image-smoke:${{ github.sha }}
+                  provenance: false
+                  sbom: false
+
+            - name: Smoke-test production image
+              env:
+                  EXPECTED_ARCHITECTURE: ${{ vars.SYSTEM_ARCH == 'aarch64' && 'arm64' || 'amd64' }}
+              run: .github/scripts/smoke-production-image.sh pingcrm-image-smoke:${{ github.sha }}
 
     zizmor:
         name: zizmor (audit workflows)

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Base Stage
 ############################################
 # Digest-pinned (supply chain): reproducible builds, and every upstream
-# rebuild of the tag lands as a reviewable Dependabot PR (tag + digest kept
+# rebuild of the tag lands as a reviewable Renovate PR (tag + digest kept
 # in sync). Bumping PHP stays a deliberate move: Dockerfile, setup-php
 # (build.yml/ci.yml) and composer.json move together.
 FROM serversideup/php:8.5.8-frankenphp@sha256:a0f4447da7612f9bca3c982d0cf33a607cbddf828f4b96a44bfa9f6f037007b6 AS base


### PR DESCRIPTION
## What changed

- add a dedicated base-image policy job
- verify the pinned OCI index and attached BuildKit/SLSA provenance for amd64 and arm64 against the successful upstream GitHub Actions run
- install Trivy 0.72.0 from checksum-pinned release archives and reject only newly introduced, fixable HIGH/CRITICAL vulnerabilities relative to the PR base
- add a production-image job on the configured deployment architecture
- build production assets and SSR against PostgreSQL, load the final App image, run migrations from that image, verify runtime assets/extensions/architecture, then boot it and require a healthy `/up` response

## Why

The shared Renovate preset now exempts only `serversideup/php` digest updates from the unreliable Docker Hub release-age timestamp. PingCRM previously tested PHP, browser and frontend behavior but did not build or execute the final container in PR CI. These gates replace the timer with checks on the immutable digest and the artifact that will actually be released.

The upstream provenance is content-addressed but not currently backed by a separately verified upstream Sigstore signature. The pinned OCI digest remains the root of trust; source, builder, workflow and materials completeness are independently checked against GitHub.

## Validation

- Bash syntax and ShellCheck for all three new scripts
- Actionlint on the changed CI workflow
- provenance verified locally for the current and proposed digest on amd64 and arm64
- Trivy delta scan on both architectures: no newly introduced fixable HIGH/CRITICAL vulnerability
- `git diff --check`
- the PR CI will run the complete PingCRM PHP, browser, frontend, Vite, production-image smoke and zizmor gates