### PR TITLE
Fix blocked Composer security updates and align PHP runtime

### DIFF
--- a/.github/scripts/verify-php-runtime-alignment.sh
+++ b/.github/scripts/verify-php-runtime-alignment.sh
@@ -8,6 +8,7 @@ workflow_files=(
     .github/workflows/build-image.yml
     .github/workflows/ci.yml
 )
+ci_workflow=.github/workflows/ci.yml
 
 image_ref=$(awk '
     $1 == "FROM" && $2 ~ /^serversideup\/php:[^@[:space:]]+@sha256:[0-9a-f]{64}$/ {
@@ -40,7 +41,39 @@ if [[ "$composer_php_version" != "$production_php_version" ]]; then
     exit 1
 fi
 
-declaration_pattern="^[[:space:]]*php-version:[[:space:]]*'([0-9]+\.[0-9]+\.[0-9]+)'[[:space:]]*$"
+if ! composer_php_constraint=$(jq -er '.require.php // empty' "$composer_file"); then
+    echo "Expected require.php in $composer_file." >&2
+    exit 1
+fi
+
+expected_php_constraint="^$production_php_version"
+
+if [[ "$composer_php_constraint" != "$expected_php_constraint" ]]; then
+    echo "Composer requires PHP $composer_php_constraint; expected $expected_php_constraint so Renovate can bump the runtime floor." >&2
+    exit 1
+fi
+
+ci_image_ref=$(awk '
+    $1 == "image:" && $2 ~ /^serversideup\/php:[^@[:space:]]+@sha256:[0-9a-f]{64}$/ {
+        references[++count] = $2
+    }
+    END {
+        if (count != 1) {
+            printf "Expected exactly one digest-pinned ServerSideUp CI container, found %d.\n", count > "/dev/stderr"
+            exit 1
+        }
+
+        print references[1]
+    }
+' "$ci_workflow")
+
+if [[ "$ci_image_ref" != "$image_ref" ]]; then
+    echo "The CI parity container uses $ci_image_ref, but the production base uses $image_ref." >&2
+    exit 1
+fi
+
+production_php_line=${production_php_version%.*}
+declaration_pattern="^[[:space:]]*php-version:[[:space:]]*'([0-9]+\.[0-9]+)'[[:space:]]*$"
 declaration_count=0
 
 for workflow_file in "${workflow_files[@]}"; do
@@ -48,14 +81,14 @@ for workflow_file in "${workflow_files[@]}"; do
         ((declaration_count += 1))
 
         if [[ ! "$declaration" =~ $declaration_pattern ]]; then
-            echo "Expected an exact PHP patch version in $workflow_file: $declaration" >&2
+            echo "Expected a major.minor setup-php compatibility declaration in $workflow_file: $declaration" >&2
             exit 1
         fi
 
         workflow_php_version=${BASH_REMATCH[1]}
 
-        if [[ "$workflow_php_version" != "$production_php_version" ]]; then
-            echo "$workflow_file targets PHP $workflow_php_version, but the production image uses PHP $production_php_version." >&2
+        if [[ "$workflow_php_version" != "$production_php_line" ]]; then
+            echo "$workflow_file targets PHP $workflow_php_version, but the production image uses the $production_php_line line." >&2
             exit 1
         fi
     done < <(awk '/php-version:/' "$workflow_file")
@@ -66,4 +99,4 @@ if ((declaration_count == 0)); then
     exit 1
 fi
 
-echo "Verified PHP $production_php_version across Docker, Composer and $declaration_count setup-php declarations."
+echo "Verified PHP $production_php_version across Docker, Composer and the exact CI container; $declaration_count setup-php jobs track the $production_php_line compatibility line."

--- a/.github/scripts/verify-php-runtime-alignment.sh
+++ b/.github/scripts/verify-php-runtime-alignment.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+dockerfile=${1:-Dockerfile}
+composer_file=${2:-composer.json}
+workflow_files=(
+    .github/workflows/build-image.yml
+    .github/workflows/ci.yml
+)
+
+image_ref=$(awk '
+    $1 == "FROM" && $2 ~ /^serversideup\/php:[^@[:space:]]+@sha256:[0-9a-f]{64}$/ {
+        references[++count] = $2
+    }
+    END {
+        if (count != 1) {
+            printf "Expected exactly one digest-pinned ServerSideUp base, found %d.\n", count > "/dev/stderr"
+            exit 1
+        }
+
+        print references[1]
+    }
+' "$dockerfile")
+
+if [[ ! "$image_ref" =~ ^serversideup/php:([0-9]+\.[0-9]+\.[0-9]+)-frankenphp@sha256:[0-9a-f]{64}$ ]]; then
+    echo "Expected one digest-pinned serversideup/php:<version>-frankenphp base in $dockerfile." >&2
+    exit 1
+fi
+
+production_php_version=${BASH_REMATCH[1]}
+
+if ! composer_php_version=$(jq -er '.config.platform.php // empty' "$composer_file"); then
+    echo "Expected config.platform.php in $composer_file." >&2
+    exit 1
+fi
+
+if [[ "$composer_php_version" != "$production_php_version" ]]; then
+    echo "Composer targets PHP $composer_php_version, but the production image uses PHP $production_php_version." >&2
+    exit 1
+fi
+
+declaration_pattern="^[[:space:]]*php-version:[[:space:]]*'([0-9]+\.[0-9]+\.[0-9]+)'[[:space:]]*$"
+declaration_count=0
+
+for workflow_file in "${workflow_files[@]}"; do
+    while IFS= read -r declaration; do
+        ((declaration_count += 1))
+
+        if [[ ! "$declaration" =~ $declaration_pattern ]]; then
+            echo "Expected an exact PHP patch version in $workflow_file: $declaration" >&2
+            exit 1
+        fi
+
+        workflow_php_version=${BASH_REMATCH[1]}
+
+        if [[ "$workflow_php_version" != "$production_php_version" ]]; then
+            echo "$workflow_file targets PHP $workflow_php_version, but the production image uses PHP $production_php_version." >&2
+            exit 1
+        fi
+    done < <(awk '/php-version:/' "$workflow_file")
+done
+
+if ((declaration_count == 0)); then
+    echo "Expected at least one setup-php version declaration." >&2
+    exit 1
+fi
+
+echo "Verified PHP $production_php_version across Docker, Composer and $declaration_count setup-php declarations."

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
-          php-version: '8.5.8'
+          php-version: '8.5'
           extensions: dom, curl, libxml, mbstring, zip, pdo, pdo_pgsql, bcmath, intl
           coverage: none
           tools: composer:v2

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
-          php-version: '8.5'
+          php-version: '8.5.8'
           extensions: dom, curl, libxml, mbstring, zip, pdo, pdo_pgsql, bcmath, intl
           coverage: none
           tools: composer:v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
               with:
                   persist-credentials: false
 
+            - name: Verify PHP runtime alignment
+              run: .github/scripts/verify-php-runtime-alignment.sh
+
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
@@ -89,13 +92,18 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
               with:
-                  php-version: '8.5'
+                  php-version: '8.5.8'
                   extensions: dom, curl, libxml, mbstring, zip, pdo, pdo_sqlite, sqlite3, bcmath, intl
                   coverage: none
                   tools: composer:v2
 
             - name: Install Composer dependencies
               uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
+
+            - name: Verify Composer platform requirements
+              run: |
+                  test "$(php -r 'echo PHP_VERSION;')" = "$(composer config platform.php)"
+                  composer check-platform-reqs --lock
 
             - name: Prepare Laravel environment
               run: |
@@ -120,7 +128,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
               with:
-                  php-version: '8.5'
+                  php-version: '8.5.8'
                   extensions: dom, curl, libxml, mbstring, zip, pdo, pdo_sqlite, sqlite3, bcmath, intl
                   coverage: none
                   tools: composer:v2
@@ -159,7 +167,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
               with:
-                  php-version: '8.5'
+                  php-version: '8.5.8'
                   extensions: dom, curl, libxml, mbstring, zip, pdo, pdo_sqlite, sqlite3, bcmath, intl
                   coverage: none
                   tools: composer:v2
@@ -209,7 +217,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
               with:
-                  php-version: '8.5'
+                  php-version: '8.5.8'
                   extensions: dom, curl, libxml, mbstring, zip, pdo, pdo_sqlite, sqlite3, bcmath, intl
                   coverage: none
                   tools: composer:v2
@@ -266,7 +274,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
               with:
-                  php-version: '8.5'
+                  php-version: '8.5.8'
                   extensions: dom, curl, libxml, mbstring, zip, pdo, pdo_pgsql, bcmath, intl
                   coverage: none
                   tools: composer:v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,24 @@ jobs:
     php:
         name: PHP (Pint + Pest)
         runs-on: ubuntu-24.04
+        container:
+            image: serversideup/php:8.5.8-frankenphp@sha256:0e3ccba461b7054bac70f42f379bfa9d45614e62ac221003ef9271551516706f
+            options: --user root
+
+        defaults:
+            run:
+                shell: bash
 
         steps:
+            - name: Install CI system and PHP dependencies
+              env:
+                  DEBIAN_FRONTEND: noninteractive
+              run: |
+                  apt-get update
+                  apt-get install -y --no-install-recommends git
+                  rm -rf /var/lib/apt/lists/*
+                  install-php-extensions bcmath intl sockets
+
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                 persist-credentials: false
@@ -88,14 +104,6 @@ jobs:
                       echo '::error::Production runtime environments must never be CI build inputs.'
                       exit 1
                   fi
-
-            - name: Setup PHP
-              uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
-              with:
-                  php-version: '8.5.8'
-                  extensions: dom, curl, libxml, mbstring, zip, pdo, pdo_sqlite, sqlite3, bcmath, intl
-                  coverage: none
-                  tools: composer:v2
 
             - name: Install Composer dependencies
               uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
@@ -128,7 +136,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
               with:
-                  php-version: '8.5.8'
+                  php-version: '8.5'
                   extensions: dom, curl, libxml, mbstring, zip, pdo, pdo_sqlite, sqlite3, bcmath, intl
                   coverage: none
                   tools: composer:v2
@@ -167,7 +175,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
               with:
-                  php-version: '8.5.8'
+                  php-version: '8.5'
                   extensions: dom, curl, libxml, mbstring, zip, pdo, pdo_sqlite, sqlite3, bcmath, intl
                   coverage: none
                   tools: composer:v2
@@ -217,7 +225,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
               with:
-                  php-version: '8.5.8'
+                  php-version: '8.5'
                   extensions: dom, curl, libxml, mbstring, zip, pdo, pdo_sqlite, sqlite3, bcmath, intl
                   coverage: none
                   tools: composer:v2
@@ -274,7 +282,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
               with:
-                  php-version: '8.5.8'
+                  php-version: '8.5'
                   extensions: dom, curl, libxml, mbstring, zip, pdo, pdo_pgsql, bcmath, intl
                   coverage: none
                   tools: composer:v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@
 ############################################
 # Digest-pinned (supply chain): reproducible builds, and every upstream
 # rebuild of the tag lands as a reviewable Renovate PR (tag + digest kept
-# in sync). Bumping PHP stays a deliberate move: Dockerfile, setup-php
-# (build.yml/ci.yml) and composer.json move together.
+# in sync). Renovate moves this base, the exact CI parity container and
+# Composer's constraints/lock together; setup-php tracks the same minor line.
 FROM serversideup/php:8.5.8-frankenphp@sha256:0e3ccba461b7054bac70f42f379bfa9d45614e62ac221003ef9271551516706f AS base
 
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,13 +50,15 @@ FROM base AS builder
 
 COPY --link composer.json composer.lock ./
 
-RUN composer install \
+RUN test "$(php -r 'echo PHP_VERSION;')" = "$(composer config platform.php)" \
+    && composer install \
     --no-dev \
     --no-interaction \
     --no-autoloader \
     --no-ansi \
     --no-scripts \
-    --audit
+    --audit \
+    && composer check-platform-reqs --lock --no-dev
 
 COPY --link . .
 

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^8.5",
+        "php": "^8.5.8",
         "fakerphp/faker": "^1.24",
         "inertiajs/inertia-laravel": "^3.0",
         "laravel-lang/common": "^6.7",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": ">=8.4",
+        "php": "^8.5",
         "fakerphp/faker": "^1.24",
         "inertiajs/inertia-laravel": "^3.0",
         "laravel-lang/common": "^6.7",
@@ -89,6 +89,10 @@
     },
     "config": {
         "optimize-autoloader": true,
+        "platform": {
+            "php": "8.5.8"
+        },
+        "platform-check": true,
         "preferred-install": "dist",
         "sort-packages": true,
         "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "899a8a5af18addb177b7052cbba55062",
+    "content-hash": "d93b9e135dbcfdae9dc95de4234cbbe7",
     "packages": [
         {
             "name": "archtechx/enums",
@@ -1520,21 +1520,21 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.15.1",
+            "version": "7.15.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f"
+                "reference": "ae311b8f045ea93ce7b1c9cdb7cec06c53f944bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ae311b8f045ea93ce7b1c9cdb7cec06c53f944bc",
+                "reference": "ae311b8f045ea93ce7b1c9cdb7cec06c53f944bc",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.5.1",
+                "guzzlehttp/promises": "^2.5.2",
                 "guzzlehttp/psr7": "^2.13",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
@@ -1628,7 +1628,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.15.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.3"
             },
             "funding": [
                 {
@@ -1644,20 +1644,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-18T11:23:11+00:00"
+            "time": "2026-08-05T19:48:21+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.5.1",
+            "version": "2.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29"
+                "reference": "2823687acff28b2dbe67b2508a6b300e2c3fa4ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/9ad1e4fc607446a055b95870c7f668e93b5cff29",
-                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/2823687acff28b2dbe67b2508a6b300e2c3fa4ce",
+                "reference": "2823687acff28b2dbe67b2508a6b300e2c3fa4ce",
                 "shasum": ""
             },
             "require": {
@@ -1712,7 +1712,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.5.1"
+                "source": "https://github.com/guzzle/promises/tree/2.5.2"
             },
             "funding": [
                 {
@@ -1728,7 +1728,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-08T15:48:39+00:00"
+            "time": "2026-08-05T19:30:54+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -4457,16 +4457,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.8.2",
+            "version": "2.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "59fb075d2101740c337c7216e3f32b36c204218b"
+                "reference": "72e9a87efcf41a8e83be3ed0866b69d77565cb12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/59fb075d2101740c337c7216e3f32b36c204218b",
-                "reference": "59fb075d2101740c337c7216e3f32b36c204218b",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/72e9a87efcf41a8e83be3ed0866b69d77565cb12",
+                "reference": "72e9a87efcf41a8e83be3ed0866b69d77565cb12",
                 "shasum": ""
             },
             "require": {
@@ -4488,8 +4488,8 @@
                 "github/gfm": "0.29.0",
                 "michelf/php-markdown": "^1.4 || ^2.0",
                 "nyholm/psr7": "^1.5",
-                "phpstan/phpstan": "^1.8.2",
-                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
+                "phpstan/phpstan": "^2.0.0",
+                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0 || ^12.0.0 || ^13.0.0",
                 "scrutinizer/ocular": "^1.8.1",
                 "symfony/finder": "^5.3 | ^6.0 | ^7.0 || ^8.0",
                 "symfony/process": "^5.4 | ^6.0 | ^7.0 || ^8.0",
@@ -4503,7 +4503,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.9-dev"
+                    "dev-main": "2.10-dev"
                 }
             },
             "autoload": {
@@ -4560,7 +4560,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-19T13:16:38+00:00"
+            "time": "2026-08-11T00:58:45+00:00"
         },
         {
             "name": "league/config",
@@ -15597,8 +15597,11 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.4"
+        "php": "^8.5"
     },
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.5.8"
+    },
     "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d93b9e135dbcfdae9dc95de4234cbbe7",
+    "content-hash": "15bcc078cd40b653ffd84a5cd4457897",
     "packages": [
         {
             "name": "archtechx/enums",
@@ -15597,7 +15597,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.5"
+        "php": "^8.5.8"
     },
     "platform-dev": {},
     "platform-overrides": {

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,34 @@
   "extends": [
     "github>fouteox/renovate-config",
     "github>fouteox/renovate-config:apps"
+  ],
+  "customManagers": [
+    {
+      "description": "Keep Composer's platform and setup-php aligned with the production ServerSideUp PHP image.",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^composer\\.json$/",
+        "/^\\.github/workflows/(?:build-image|ci)\\.yml$/"
+      ],
+      "matchStrings": [
+        "\\\"platform\\\"\\s*:\\s*\\{[^}]*\\\"php\\\"\\s*:\\s*\\\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\\\"",
+        "php-version:\\s*'(?<currentValue>\\d+\\.\\d+\\.\\d+)'"
+      ],
+      "depNameTemplate": "serversideup/php",
+      "packageNameTemplate": "serversideup/php",
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^(?<version>\\d+\\.\\d+\\.\\d+)-frankenphp$"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Update the production image, Composer platform and CI runtime atomically.",
+      "matchPackageNames": [
+        "serversideup/php"
+      ],
+      "groupName": "PHP runtime",
+      "groupSlug": "php-runtime"
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -6,17 +6,15 @@
   ],
   "customManagers": [
     {
-      "description": "Keep Composer's platform and setup-php aligned with the production ServerSideUp PHP image.",
+      "description": "Keep Composer's platform aligned with the production ServerSideUp PHP image.",
       "customType": "regex",
       "managerFilePatterns": [
-        "/^composer\\.json$/",
-        "/^\\.github/workflows/(?:build-image|ci)\\.yml$/"
+        "/^composer\\.json$/"
       ],
       "matchStrings": [
-        "\\\"platform\\\"\\s*:\\s*\\{[^}]*\\\"php\\\"\\s*:\\s*\\\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\\\"",
-        "php-version:\\s*'(?<currentValue>\\d+\\.\\d+\\.\\d+)'"
+        "\\\"platform\\\"\\s*:\\s*\\{[^}]*\\\"php\\\"\\s*:\\s*\\\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\\\""
       ],
-      "depNameTemplate": "serversideup/php",
+      "depNameTemplate": "php",
       "packageNameTemplate": "serversideup/php",
       "datasourceTemplate": "docker",
       "versioningTemplate": "semver",
@@ -25,9 +23,23 @@
   ],
   "packageRules": [
     {
-      "description": "Update the production image, Composer platform and CI runtime atomically.",
+      "description": "Bump the application PHP floor so Composer updates its lock artifact.",
+      "matchManagers": [
+        "composer"
+      ],
+      "matchDepNames": [
+        "php"
+      ],
       "matchPackageNames": [
-        "serversideup/php"
+        "containerbase/php-prebuild"
+      ],
+      "rangeStrategy": "bump"
+    },
+    {
+      "description": "Update the production image, exact CI container and Composer platform atomically.",
+      "matchPackageNames": [
+        "serversideup/php",
+        "containerbase/php-prebuild"
       ],
       "groupName": "PHP runtime",
       "groupSlug": "php-runtime"


### PR DESCRIPTION
## Why

Dependabot security updates for Guzzle and CommonMark are currently blocked by a synthetic PHP platform mismatch:

- the updater runs PHP 8.4.24 with Composer 2.9.5;
- the root constraint `>=8.4` is lowered by Dependabot to PHP 8.4.0;
- the existing lock contains `symfony/console` 8.1.0, which requires PHP >=8.4.1 through the development dependency graph;
- Composer therefore rejects the already-valid lock before it can update either vulnerable package.

Production is actually running PHP 8.5.8 in `ghcr.io/fouteox/pingcrm-react-inertia-laravel:run-45.1.0@sha256:2716fb3ed3c25c2546f57880e38ac84ec2a665f0a8e332e4fe686b41c0992384`.

## What changed

- constrain the supported runtime to PHP `^8.5.8` and model production explicitly with `config.platform.php=8.5.8`;
- run the PHP parity job in the exact digest-pinned ServerSideUp production image, keep the other `setup-php` compatibility jobs on the PHP 8.5 line, and verify those invariants automatically;
- make the Docker builder reject runtime drift and run `composer check-platform-reqs --lock --no-dev` after its audited production install;
- teach Renovate 44.23.3 to update the ServerSideUp production image, exact CI container, Composer runtime floor, platform override and lock artifact in one `PHP runtime` group;
- update the vulnerable lock entries:
  - `guzzlehttp/guzzle` 7.15.1 -> 7.15.3;
  - `guzzlehttp/promises` 2.5.1 -> 2.5.2;
  - `league/commonmark` 2.8.2 -> 2.9.2.

Guzzle 7.15.3 is the newest compatible 7.x release. Guzzle 8 is currently excluded by Laravel 13, Laravel Boost and Pusher constraints.

## Release-age exception

The normal Renovate cooldown remains three days. Guzzle 7.15.3 was published on 2026-08-05 and satisfies it.

CommonMark 2.9.2 was published on 2026-08-11, so this is an explicit security exception: 2.9.1 (2026-08-09) is itself a security release for additional DoS and XSS issues, while 2.9.2 fixes a behavioral regression introduced in the 2.9.0 security line. Waiting would leave eight known alerts open and selecting only 2.9.0 would omit newer security fixes and keep the regression.

## Validation

- exact Dependabot reproduction: PHP 8.4.24 + Composer 2.9.5, targeted update dry-run, lock unchanged, no advisories;
- `composer validate --strict`;
- `composer audit --locked`;
- `composer check-platform-reqs --lock` on PHP 8.5.8;
- Pest Unit/Feature/Arch: 20 passed, 425 assertions (the suite reports 105 existing warnings);
- production Docker `builder` target, including audited `--no-dev` install and platform check;
- PHP alignment script + `bash -n` + ShellCheck;
- `actionlint .github/workflows/ci.yml` (the unchanged `job.workflow_ref` expression in `build-image.yml` is not understood by the locally installed actionlint, and fails identically on `main`);
- Renovate 44.23.3 config validator, native Composer plus Docker/Actions/custom-manager extraction, package-rule application and atomic `PHP runtime` grouping;
- branch based on current `main` at `b23c2b3d9064a697d87cfc6f657238569390d254`.

## References

- [Composer platform emulation and runtime checks](https://getcomposer.org/doc/06-config.md#platform)
- [Composer `check-platform-reqs`](https://getcomposer.org/doc/03-cli.md#check-platform-reqs)
- [Renovate regex custom managers](https://docs.renovatebot.com/modules/manager/regex/)
- [GitHub Dependabot update errors](https://docs.github.com/code-security/dependabot/working-with-dependabot/troubleshooting-dependabot-errors)
- [Guzzle 7.15.3](https://github.com/guzzle/guzzle/releases/tag/7.15.3)
- [CommonMark 2.9.1 security release](https://github.com/thephpleague/commonmark/releases/tag/2.9.1)
- [CommonMark 2.9.2 regression fix](https://github.com/thephpleague/commonmark/releases/tag/2.9.2)
