### PR TITLE
Expose les options Caddy nécessaires au drain Octane

### DIFF
--- a/config/octane.php
+++ b/config/octane.php
@@ -57,6 +57,24 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | FrankenPHP Caddy Environment
+    |--------------------------------------------------------------------------
+    |
+    | Octane builds an explicit environment for the FrankenPHP child process.
+    | These opt-in values allow production to add Caddy directives without
+    | replacing Octane's native defaults when no override is configured.
+    |
+    */
+
+    'caddy' => [
+        'env' => array_filter([
+            'CADDY_GLOBAL_OPTIONS' => env('OCTANE_CADDY_GLOBAL_OPTIONS'),
+            'CADDY_SERVER_EXTRA_DIRECTIVES' => env('OCTANE_CADDY_SERVER_EXTRA_DIRECTIVES'),
+        ], static fn (mixed $value): bool => $value !== null),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Octane Listeners
     |--------------------------------------------------------------------------
     |

--- a/tests/Unit/OctaneCaddyConfigTest.php
+++ b/tests/Unit/OctaneCaddyConfigTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Env;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+it('passes explicit Caddy drain snippets to the Octane FrankenPHP process', function () {
+    $repository = Env::getRepository();
+    $variables = [
+        'OCTANE_CADDY_GLOBAL_OPTIONS' => "metrics\ngrace_period 100s",
+        'OCTANE_CADDY_SERVER_EXTRA_DIRECTIVES' => <<<'CADDY'
+            @drainMetrics {
+                path /.well-known/frankenphp-drain/metrics
+            }
+            metrics @drainMetrics
+            CADDY,
+    ];
+    $originalValues = collect(array_keys($variables))
+        ->mapWithKeys(fn (string $key): array => [$key => $repository->get($key)]);
+
+    try {
+        foreach ($variables as $key => $value) {
+            $repository->set($key, $value);
+        }
+
+        $octane = require config_path('octane.php');
+
+        expect($octane)->toHaveKey('caddy.env')
+            ->and($octane['caddy']['env'])->toBe([
+                'CADDY_GLOBAL_OPTIONS' => $variables['OCTANE_CADDY_GLOBAL_OPTIONS'],
+                'CADDY_SERVER_EXTRA_DIRECTIVES' => $variables['OCTANE_CADDY_SERVER_EXTRA_DIRECTIVES'],
+            ]);
+    } finally {
+        foreach ($originalValues as $key => $value) {
+            $value === null ? $repository->clear($key) : $repository->set($key, $value);
+        }
+    }
+});
+
+it('leaves the native Octane Caddy defaults untouched without explicit overrides', function () {
+    $repository = Env::getRepository();
+    $keys = ['OCTANE_CADDY_GLOBAL_OPTIONS', 'OCTANE_CADDY_SERVER_EXTRA_DIRECTIVES'];
+    $originalValues = collect($keys)
+        ->mapWithKeys(fn (string $key): array => [$key => $repository->get($key)]);
+
+    try {
+        foreach ($keys as $key) {
+            $repository->clear($key);
+        }
+
+        $octane = require config_path('octane.php');
+
+        expect($octane)->toHaveKey('caddy.env')
+            ->and($octane['caddy']['env'])->toBe([]);
+    } finally {
+        foreach ($originalValues as $key => $value) {
+            $value === null ? $repository->clear($key) : $repository->set($key, $value);
+        }
+    }
+});


### PR DESCRIPTION
## Pourquoi

PingCRM doit exposer les métriques FrankenPHP uniquement sur le loopback afin que le hook `preStop` puisse attendre la fin des requêtes avant l'arrêt du pod.

Sur l'image de production exacte, poser `CADDY_GLOBAL_OPTIONS` et `CADDY_SERVER_EXTRA_DIRECTIVES` sur le conteneur ne fonctionne pas : Octane 2.18 construit explicitement l'environnement de son processus FrankenPHP, puis applique [`config('octane.caddy.env')`](https://github.com/laravel/octane/blob/404a2f98370c5dea7fb65ecce03c807e8d324074/src/Commands/StartFrankenPhpCommand.php#L112-L133) en dernier.

## Changements

- expose deux variables opt-in à travers `octane.caddy.env` :
  - `OCTANE_CADDY_GLOBAL_OPTIONS` vers `CADDY_GLOBAL_OPTIONS` ;
  - `OCTANE_CADDY_SERVER_EXTRA_DIRECTIVES` vers `CADDY_SERVER_EXTRA_DIRECTIVES` ;
- conserve les valeurs natives d'Octane lorsque ces variables sont absentes ;
- couvre les deux comportements par des tests unitaires.

Cette PR ne modifie donc pas le comportement de production tant que GitOps ne fournit pas explicitement les nouvelles variables.

## Validation

- TDD : tests rouges sans la section `caddy.env`, puis verts ;
- `vendor/bin/pint --test config/octane.php tests/Unit/OctaneCaddyConfigTest.php` ;
- suites Unit, Feature et Arch : **127 tests, 429 assertions** ;
- `php artisan config:cache` avec les deux valeurs multilignes, puis contrôle du rendu ;
- OrbStack avec l'image de production exacte `run-53.1.0@sha256:b57328f1243224cd6869cb41994337ff0ebfdfc77e0853a15c584a8d0cd602fb` et ce fichier monté :
  - `/up` : **200** ;
  - métriques depuis le loopback du conteneur : **200** ;
  - même route depuis le port publié sur l'hôte : **404** ;
  - variables Caddy présentes dans le processus enfant FrankenPHP ;
  - métriques worker et files disponibles pour le futur helper de drain.

Le test a aussi confirmé une différence avec Footeox : en mode workers Octane, les workers au repos occupent déjà des threads. Le helper PingCRM devra attendre `frankenphp_busy_workers == 0` et les files vides, pas `frankenphp_busy_threads == 0`.

## Ordre de déploiement

La PR GitOps qui suspend `ImageUpdateAutomation/pingcrm` doit être mergée et convergée avant celle-ci. Ainsi, la construction de cette nouvelle image ne peut pas provoquer un rollout automatique sans drain.
