### PR TITLE
Corriger l’alignement atomique du runtime PHP

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,19 @@
       "rangeStrategy": "bump"
     },
     {
+      "description": "Composer's platform field stores a PHP version, not an image reference, so it cannot carry an OCI digest.",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchFileNames": [
+        "composer.json"
+      ],
+      "matchPackageNames": [
+        "serversideup/php"
+      ],
+      "pinDigests": false
+    },
+    {
       "description": "Update the production image, exact CI container and Composer platform atomically.",
       "matchPackageNames": [
         "serversideup/php",


### PR DESCRIPTION
## Pourquoi

Le preset partagé `docker:pinDigests` s'applique aussi au gestionnaire regex qui suit `config.platform.php` dans `composer.json`. Ce champ ne peut contenir qu'une version PHP, pas un digest OCI.

Lors du passage de `8.5.8-frankenphp` à `8.5.9-frankenphp`, Renovate 44.35.4 :

- résout correctement les deux images et le digest de `8.5.9-frankenphp` ;
- tente ensuite de résoudre les tags Docker nus inexistants `8.5.8` et `8.5.9` pour le champ Composer ;
- abandonne cette troisième mise à jour et rend donc le groupe `PHP runtime` non atomique.

## Changement

Désactive `pinDigests` uniquement pour la dépendance `serversideup/php` extraite par `custom.regex` dans `composer.json`.

Le pinning tag + digest reste inchangé pour :

- le `Dockerfile` de production ;
- le conteneur PHP exact des workflows GitHub Actions ;
- toutes les autres images du dépôt.

Cette exception ciblée suit le mécanisme documenté par Renovate pour les gestionnaires dont le fichier ne peut pas porter de digest :

- https://docs.renovatebot.com/presets-docker/#dockerpindigests
- https://docs.renovatebot.com/modules/manager/regex/

## Validation

- `git diff --check` ;
- validation de `renovate.json` avec l'image exacte `ghcr.io/renovatebot/renovate:44.35.4@sha256:e49d14979ef91b6ac7a968188cfd7a641f7bdf315957873f73fc4e9efba2c666` ;
- lookup local avec cette même image et les presets partagés courants :
  - aucune requête de manifeste vers les tags nus `8.5.8` ou `8.5.9` ;
  - `composer.json` propose bien `8.5.9` ;
  - les deux images proposent `8.5.9-frankenphp@sha256:ed948d6066755a5216c466c1e4da59b7020d958bac42f6da00e6189940d1853f` ;
  - les trois mises à jour rejoignent la branche `php-runtime`.

## Limite vérifiée

Le lookup local anonyme atteint la limite de pagination Docker Hub après 1 000 tags. Cela n'a pas empêché la résolution des versions concernées ; le runner de production reste authentifié avec son jeton court Docker Hub.
