### PR TITLE
Préparer la configuration Renovate self-hosted

### DIFF
--- a/renovate-self-hosted.json
+++ b/renovate-self-hosted.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Configuration spécifique à PingCRM pour Renovate self-hosted. La politique commune est fournie par fouteox/renovate-runner.",
+  "customManagers": [
+    {
+      "description": "Keep Composer's platform aligned with the production ServerSideUp PHP image.",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^composer\\.json$/"
+      ],
+      "matchStrings": [
+        "\\\"platform\\\"\\s*:\\s*\\{[^}]*\\\"php\\\"\\s*:\\s*\\\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\\\""
+      ],
+      "depNameTemplate": "php",
+      "packageNameTemplate": "serversideup/php",
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^(?<version>\\d+\\.\\d+\\.\\d+)-frankenphp$"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Bump the application PHP floor so Composer updates its lock artifact.",
+      "matchManagers": [
+        "composer"
+      ],
+      "matchDepNames": [
+        "php"
+      ],
+      "matchPackageNames": [
+        "containerbase/php-prebuild"
+      ],
+      "rangeStrategy": "bump"
+    },
+    {
+      "description": "Composer's platform field stores a PHP version, not an image reference, so it cannot carry an OCI digest.",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchFileNames": [
+        "composer.json"
+      ],
+      "matchPackageNames": [
+        "serversideup/php"
+      ],
+      "pinDigests": false
+    },
+    {
+      "description": "Update the production image, exact CI container and Composer platform atomically.",
+      "matchPackageNames": [
+        "serversideup/php",
+        "containerbase/php-prebuild"
+      ],
+      "groupName": "PHP runtime",
+      "groupSlug": "php-runtime"
+    }
+  ]
+}


### PR DESCRIPTION
## Objectif

Préparer le cutover de PingCRM vers fouteox/renovate-runner sans interrompre le service Mend-hosted actuel.

## Changement

- ajoute renovate-self-hosted.json, volontairement ignoré par Mend et par le runner actuel ;
- conserve à l’identique les customManagers et packageRules propres à PingCRM ;
- retire uniquement les deux extends vers le preset public de cette configuration alternative ;
- documente que la politique commune sera injectée depuis le checkout de confiance de renovate-runner.

Cette PR ne change donc encore aucun comportement en production. Le runner sélectionnera explicitement ce fichier dans une étape ultérieure, après validation dry-run.

## Vérifications

- parité JSON des règles locales avec renovate.json ;
- renovate-config-validator --strict --no-global avec l’image exacte Renovate 44.37.1 épinglée par le runner ;
- test moteur hors réseau : sélection effective de renovate-self-hosted.json et aucune résolution de fouteox/renovate-config comme preset de configuration ;
- git diff --check.