### PR TITLE
Retirer le preset Renovate public de PingCRM

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>fouteox/renovate-config",
-    "github>fouteox/renovate-config:apps"
-  ],
+  "description": "Configuration spécifique à PingCRM pour Renovate self-hosted. La politique commune est fournie par fouteox/renovate-runner.",
   "customManagers": [
     {
       "description": "Keep Composer's platform aligned with the production ServerSideUp PHP image.",


### PR DESCRIPTION
## Objet

Retirer de PingCRM les dernières références au preset public `fouteox/renovate-config`, en première phase de la fermeture du dépôt public.

## Absence de changement de comportement

Le runner self-hosted exige et lit toujours `renovate-self-hosted.json` en priorité. Cette PR rend le fichier standard `renovate.json` strictement identique à ce fichier actif :

- les managers et règles spécifiques PingCRM sont inchangés ;
- la politique commune reste injectée depuis le checkout privé revu de `fouteox/renovate-runner` ;
- aucun fichier actif n'est supprimé pendant cette phase de compatibilité.

Une PR ultérieure fera converger le runner vers le nom standard `renovate.json`, puis supprimera `renovate-self-hosted.json`.

## Validation

- comparaison octet pour octet des deux configurations ;
- `jq empty renovate.json renovate-self-hosted.json` ;
- validation stricte des deux configurations dans l'image Renovate exacte `44.39.1@sha256:00699dedb6d44bf645e3f0a98729bcdb660a660f1952a53d9592d3a127088b11`, en lecture seule et sans réseau ;
- `vendor/bin/pint --dirty` ;
- `git diff --check`.

## Gate de fusion

Ne pas fusionner avant deux exécutions Footeox consécutives déclenchées par `schedule` et qualifiées après le merge de renovate-runner#54.