### PR TITLE
Keep PHP runtime Renovate updates atomic

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,6 +54,18 @@
       "groupName": "PHP runtime",
       "groupSlug": "php-runtime",
       "minimumGroupSize": 4
+    },
+    {
+      "description": "Keep same-tag ServerSideUp image rebuilds reviewable without waiting for Composer fields that have no digest.",
+      "matchPackageNames": [
+        "serversideup/php"
+      ],
+      "matchUpdateTypes": [
+        "digest"
+      ],
+      "groupName": "PHP runtime digest refresh",
+      "groupSlug": "php-runtime-digest",
+      "minimumGroupSize": 1
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -46,13 +46,14 @@
       "pinDigests": false
     },
     {
-      "description": "Update the production image, exact CI container and Composer platform atomically.",
+      "description": "Update the production image, exact CI container, Composer platform and PHP requirement atomically.",
       "matchPackageNames": [
         "serversideup/php",
         "containerbase/php-prebuild"
       ],
       "groupName": "PHP runtime",
-      "groupSlug": "php-runtime"
+      "groupSlug": "php-runtime",
+      "minimumGroupSize": 4
     }
   ]
 }

--- a/tests/Unit/RenovatePhpRuntimePolicyTest.php
+++ b/tests/Unit/RenovatePhpRuntimePolicyTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+test('php runtime updates remain atomic across every managed surface', function () {
+    $repositoryRoot = dirname(__DIR__, 2);
+    $configuration = json_decode(
+        file_get_contents($repositoryRoot.'/renovate.json'),
+        true,
+        512,
+        JSON_THROW_ON_ERROR,
+    );
+
+    $runtimeRule = collect($configuration['packageRules'])
+        ->firstWhere('groupSlug', 'php-runtime');
+
+    expect($runtimeRule)->not->toBeNull()
+        ->and($runtimeRule['matchPackageNames'])->toEqualCanonicalizing([
+            'serversideup/php',
+            'containerbase/php-prebuild',
+        ])
+        ->and($runtimeRule['minimumGroupSize'])->toBe(4)
+        ->and(mb_substr_count(file_get_contents($repositoryRoot.'/Dockerfile'), 'serversideup/php:'))->toBe(1)
+        ->and(mb_substr_count(file_get_contents($repositoryRoot.'/.github/workflows/ci.yml'), 'image: serversideup/php:'))->toBe(1)
+        ->and(data_get(json_decode(file_get_contents($repositoryRoot.'/composer.json'), true, 512, JSON_THROW_ON_ERROR), 'require.php'))->not->toBeNull()
+        ->and(data_get(json_decode(file_get_contents($repositoryRoot.'/composer.json'), true, 512, JSON_THROW_ON_ERROR), 'config.platform.php'))->not->toBeNull();
+});

--- a/tests/Unit/RenovatePhpRuntimePolicyTest.php
+++ b/tests/Unit/RenovatePhpRuntimePolicyTest.php
@@ -25,3 +25,21 @@ test('php runtime updates remain atomic across every managed surface', function 
         ->and(data_get(json_decode(file_get_contents($repositoryRoot.'/composer.json'), true, 512, JSON_THROW_ON_ERROR), 'require.php'))->not->toBeNull()
         ->and(data_get(json_decode(file_get_contents($repositoryRoot.'/composer.json'), true, 512, JSON_THROW_ON_ERROR), 'config.platform.php'))->not->toBeNull();
 });
+
+test('same-tag image digest refreshes do not wait for Composer surfaces', function () {
+    $repositoryRoot = dirname(__DIR__, 2);
+    $configuration = json_decode(
+        file_get_contents($repositoryRoot.'/renovate.json'),
+        true,
+        512,
+        JSON_THROW_ON_ERROR,
+    );
+
+    $digestRule = collect($configuration['packageRules'])
+        ->firstWhere('groupSlug', 'php-runtime-digest');
+
+    expect($digestRule)->not->toBeNull()
+        ->and($digestRule['matchPackageNames'])->toBe(['serversideup/php'])
+        ->and($digestRule['matchUpdateTypes'])->toBe(['digest'])
+        ->and($digestRule['minimumGroupSize'])->toBe(1);
+});


### PR DESCRIPTION
## Summary

- require all four PHP runtime surfaces before Renovate creates or updates the grouped branch
- cover the production base, CI container, Composer platform, and Composer PHP requirement with a regression test
- prevent partial Composer-only PRs such as #89 from producing a stale lock artifact

## Verification

- `php artisan test --compact --testsuite=Unit,Arch` (94 tests, 121 assertions)
- `composer validate --strict --no-check-publish`
- Renovate 44.48.3 `renovate-config-validator renovate.json`
- local Renovate 44.48.3 extraction confirmed four grouped update surfaces

No existing Renovate PR or bot branch is modified by this PR.