### PR TITLE
Keep PostgreSQL integration CI compatible with the tracked major

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
               run: php artisan test --compact --testsuite=Unit,Feature,Arch
 
     demo-reset-integration:
-        name: Demo reset (PostgreSQL 18.4 + Typesense 30.2)
+        name: Demo reset (PostgreSQL 18 + Typesense 30.2)
         runs-on: ubuntu-24.04
         timeout-minutes: 20
 

--- a/tests/Integration/DemoResetPostgresTypesenseTest.php
+++ b/tests/Integration/DemoResetPostgresTypesenseTest.php
@@ -45,7 +45,7 @@ it('resets atomically on PostgreSQL 18 and converges Typesense 30.2', function (
     $postgresVersion = DB::selectOne('show server_version')->server_version;
     $typesense = new Client(config('scout.typesense.client-settings'));
 
-    expect($postgresVersion)->toStartWith('18.4')
+    expect($postgresVersion)->toStartWith('18.')
         ->and($typesense->getDebug()->retrieve()['version'])->toBe('30.2');
 
     $demoAccount = Account::factory()->create([


### PR DESCRIPTION
## Summary

- assert the supported PostgreSQL 18 major instead of freezing the integration test to patch 18.4
- keep the CI job label aligned with the floating, digest-pinned `postgres:18` contract
- allow Renovate digest updates such as #78 to validate PostgreSQL 18.6 without weakening the major-version gate

## Verification

- reproduced the target digest as PostgreSQL 18.6
- ran the complete integration test against the exact #78 PostgreSQL digest and the pinned Typesense 30.2 digest: 2 tests, 30 assertions
- `vendor/bin/pint --dirty --format agent`
- `git diff --check`

This PR does not update any image digest or Renovate branch.