### PR TITLE
Aligner PHP 8.5.10 et actualiser les images de build

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -68,7 +68,7 @@ jobs:
           # release (zizmor cache-poisoning).
           ignore-cache: '1'
 
-      - uses: voidzero-dev/setup-vp@1b32467adbe183473499fd9d5d372c3ed9641754 # v1.18.0
+      - uses: voidzero-dev/setup-vp@49c3e4e92c52e7f8392712a9267bbe71c5ab30e5 # v1.19.0
         with:
           node-version-file: .node-version
           cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         name: PHP (Pint + Pest)
         runs-on: ubuntu-24.04
         container:
-            image: serversideup/php:8.5.9-frankenphp@sha256:c8e9d95cd6b83180662f63de646937f3b304041ac4edfbd95ff8bd684467d035
+            image: serversideup/php:8.5.10-frankenphp@sha256:558d9d93d8f63a08ea6c99a48475faff557d8bd315bb81a876181e9ec1e50865
             options: --user root
 
         defaults:
@@ -225,7 +225,7 @@ jobs:
             - name: Install Composer dependencies
               uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 
-            - uses: voidzero-dev/setup-vp@1b32467adbe183473499fd9d5d372c3ed9641754 # v1.18.0
+            - uses: voidzero-dev/setup-vp@49c3e4e92c52e7f8392712a9267bbe71c5ab30e5 # v1.19.0
               with:
                   node-version-file: .node-version
                   cache: true
@@ -264,7 +264,7 @@ jobs:
             - name: Install Composer dependencies
               uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 
-            - uses: voidzero-dev/setup-vp@1b32467adbe183473499fd9d5d372c3ed9641754 # v1.18.0
+            - uses: voidzero-dev/setup-vp@49c3e4e92c52e7f8392712a9267bbe71c5ab30e5 # v1.19.0
               with:
                   node-version-file: .node-version
                   cache: true
@@ -314,7 +314,7 @@ jobs:
             - name: Install Composer dependencies
               uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 
-            - uses: voidzero-dev/setup-vp@1b32467adbe183473499fd9d5d372c3ed9641754 # v1.18.0
+            - uses: voidzero-dev/setup-vp@49c3e4e92c52e7f8392712a9267bbe71c5ab30e5 # v1.19.0
               with:
                   node-version-file: .node-version
                   cache: true
@@ -374,7 +374,7 @@ jobs:
                   composer-options: '--no-dev'
                   ignore-cache: '1'
 
-            - uses: voidzero-dev/setup-vp@1b32467adbe183473499fd9d5d372c3ed9641754 # v1.18.0
+            - uses: voidzero-dev/setup-vp@49c3e4e92c52e7f8392712a9267bbe71c5ab30e5 # v1.19.0
               with:
                   node-version-file: .node-version
                   cache: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # rebuild of the tag lands as a reviewable Renovate PR (tag + digest kept
 # in sync). Renovate moves this base, the exact CI parity container and
 # Composer's constraints/lock together; setup-php tracks the same minor line.
-FROM serversideup/php:8.5.9-frankenphp@sha256:c8e9d95cd6b83180662f63de646937f3b304041ac4edfbd95ff8bd684467d035 AS base
+FROM serversideup/php:8.5.10-frankenphp@sha256:558d9d93d8f63a08ea6c99a48475faff557d8bd315bb81a876181e9ec1e50865 AS base
 
 USER root
 
@@ -69,7 +69,7 @@ RUN composer dump-autoload --classmap-authoritative --no-dev
 # Declared as a FROM so Dependabot sees and bumps it: images referenced only
 # in a COPY --from are invisible to its docker ecosystem.
 ############################################
-FROM oven/bun:1.4-debian@sha256:5bb0f9be3a1a36a03e27c9a9dd894a3b1ad26657155c7df4dda771e17bf872ef AS bun
+FROM oven/bun:1.4-debian@sha256:4f6e31d1a54d6a3dd312daef655fc998101b5043d52e12592ac293ef04b9bc73 AS bun
 
 ############################################
 # App Image (also runs SSR via `php artisan inertia:start-ssr --runtime=bun`)

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^8.5.9",
+        "php": "^8.5.10",
         "fakerphp/faker": "^1.24.1",
         "inertiajs/inertia-laravel": "^3.3.3",
         "laravel-lang/common": "^6.8.0",
@@ -90,7 +90,7 @@
     "config": {
         "optimize-autoloader": true,
         "platform": {
-            "php": "8.5.9"
+            "php": "8.5.10"
         },
         "platform-check": true,
         "preferred-install": "dist",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e8af07e6dad7680a2ac70e753311a0b7",
+    "content-hash": "a4163cdcdfa22f8f5cb00ebf5e50ca3d",
     "packages": [
         {
             "name": "archtechx/enums",
@@ -15795,11 +15795,11 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.5.9"
+        "php": "^8.5.10"
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.5.9"
+        "php": "8.5.10"
     },
     "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
Le runtime passe à PHP 8.5.10 avec la même image ServerSideUp épinglée par digest dans Docker et le test CI de production. Les contraintes Composer et sa plateforme suivent cette version ; aucun paquet du lock Composer ne change de version ou de source.

Le stage Bun utilise le digest publié le 5 septembre et les workflows utilisent setup-vp 1.19.0, épinglé au commit vérifié `49c3e4e92c52e7f8392712a9267bbe71c5ab30e5`. Les images PHP/Bun et cette action ont dépassé les 72 heures de stabilité. Le [tag setup-vp est signé et sa release immuable](https://github.com/voidzero-dev/setup-vp/releases/tag/v1.19.0).

Validation locale : alignement des quatre surfaces PHP et des six jobs setup-php, Composer validate strict, deux tests de politique runtime (11 assertions), Zizmor sans nouveau signal et diff check. La CI complète conserve tous les contrôles, notamment la provenance des images, les vulnérabilités, PostgreSQL/Typesense, les navigateurs et le build de production.
